### PR TITLE
Fixes #19 - removes bundled generators

### DIFF
--- a/bin/help.txt
+++ b/bin/help.txt
@@ -41,9 +41,5 @@
     [0m
 
 
-The <%= 'webapp'.yellow %> generator is bundled, while others can be installed with <%= 'npm install <generator-name>'.bold %>
 
-Officially supported generators:
-<%= 'webapp angular backbone bbb ember chromeapp chrome-extension bootstrap mocha karma'.yellow %>
-
-See a list of all available generators with <%= 'npm search yeoman-generator'.bold %>
+See a list of all available generators with <%= 'npm search yeoman-generator'.bold %>. Install generators with <%= 'npm install <generator-name>'.bold %>

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
   },
   "dependencies": {
     "yeoman-generator": "~0.10.4",
-    "generator-webapp": "~0.1.6",
-    "generator-mocha": "~0.1.1",
     "colors": "~0.6.0",
     "nopt": "~2.1.1",
     "lodash": "~1.1.1",


### PR DESCRIPTION
First take on this if we do decide to go ahead with it:
- webapp, mocha generator dropped from package.json
- Revised help.txt to only mention search for/installation of generators from npm

Anything missing?
