### PR TITLE
Added `grunt-cli` and `bower` as `peerDependencies`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     "update-notifier": "~0.1.3",
     "insight": "~0.1.0"
   },
+  "peerDependencies": {
+    "grunt-cli": "~0.1.7",
+    "bower": "~0.8.6"
+  },
   "devDependencies": {
     "mocha": "~1.9.0",
     "ronn": "~0.4.0",


### PR DESCRIPTION
Added `grunt-cli` and `bower` as `peerDependencies` as [discussed here](https://github.com/yeoman/generator-angular/issues/16).

This should simplify Yeoman installation to just `npm install -g yo`!

Here's a quick way to test directly from my branch:

```
npm install -g https://nodeload.github.com/danielmcormond/yo/tar.gz/peer-dependencies
```
