### PR TITLE
Generator lookup bug

### DIFF
--- a/bin/yoyo.js
+++ b/bin/yoyo.js
@@ -3,6 +3,7 @@ var async = require('async');
 var open = require('open');
 var generator = require('yeoman-generator');
 var util = require('util');
+var path = require('path');
 
 
 // The `yo yo` generator provides users with a few common, helpful commands.
@@ -30,7 +31,10 @@ yoyo.prototype._findGenerators = function findGenerators() {
     var generatorPath = generator.resolved.replace(/(\/.*generator[^\/]*)\/.*/, '$1/package.json');
 
     return function (next) {
-      if (resolvedGenerators.indexOf(generatorPath) > -1 || !fs.existsSync(generatorPath)) {
+      var alreadyResolved = resolvedGenerators.indexOf(generatorPath) > -1;
+      var isPackageJSON = path.basename(generatorPath) === 'package.json';
+
+      if (alreadyResolved || !isPackageJSON || !fs.existsSync(generatorPath)) {
         return next();
       }
 


### PR DESCRIPTION
RE: https://github.com/yeoman/yeoman/issues/1113

One of yoyo's internal methods, `_findGenerators`, is used to find a user's installed generators' package.json files. I didn't write it carefully enough to handle the case where it couldn't find it ( :( ). The diff will show pretty clearly where the bug was, and this commit should be all it takes to fix it up. `generator.resolved` is the entire path to the `.js` file that contains the generator's function definition.

I believe the type of users affected by this are:
- someone with custom generators without package.json files
- someone who has an installed generator with a base folder name that doesn't follow the format of `*generator*` (`generator-*` is caught, (e.g. `generator-angular`))

Is there anything else I can add to this function to secure it even more?
