### PR TITLE
Fix JSON.parse() error in _findAllNpmGenerators related to issue  #49

### DIFF
--- a/bin/yoyo.js
+++ b/bin/yoyo.js
@@ -90,8 +90,11 @@ yoyo.prototype._findAllNpmGenerators = function _findAllNpmGenerators(term, cb) 
     if (err) {
       return this.emit('error', err);
     }
-
-    this.npmGenerators = JSON.parse(body);
+    try {
+      this.npmGenerators = JSON.parse(body);
+    } catch (err) {
+      return this.emit('error', new Error('A problem occurred contacting the registry.\n Unable to parse response: not valid JSON.'.bold));
+    }
     cb(term);
   }.bind(this));
 };


### PR DESCRIPTION
This is the fix related to the issue #49. If yo is unable to reach the registry and redirected to another page ( which is not a valid JSON), the Error "A problem occurred contacting the registry.\n Unable to parse response: not valid JSON." is thrown.
Hoping this could help.
