### PR TITLE
Allow node command flags to be passed to yo

### DIFF
--- a/bin/_yo
+++ b/bin/_yo
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var nopt = require('nopt');
+var chalk = require('chalk');
+var _ = require('lodash');
+var pkg = require('../package.json');
+var updateNotifier = require('update-notifier');
+var sudoBlock = require('sudo-block');
+var Insight = require('insight');
+
+var opts = nopt({
+  help: Boolean,
+  version: Boolean
+}, {
+  h: '--help',
+  v: '--version'
+});
+
+var args = opts.argv.remain;
+var cmd = args[0];
+
+var intro = _.template(fs.readFileSync(path.join(__dirname, 'help.txt'), 'utf8'));
+
+var insight = new Insight({
+  trackingCode: 'UA-31537568-1',
+  packageName: pkg.name,
+  packageVersion: pkg.version
+});
+
+if (opts.insight === false) {
+  insight.config.set('optOut', true);
+} else if (opts.insight) {
+  insight.config.set('optOut', false);
+}
+
+/*jshint multistr:true */
+var insightMsg = chalk.gray('\
+==========================================================================') + chalk.yellow('\n\
+We\'re constantly looking for ways to make ') + chalk.bold.red(pkg.name) + chalk.yellow(' better! \n\
+May we anonymously report usage statistics to improve the tool over time? \n\
+More info: yeoman.io/insight.html & http://yeoman.io') + chalk.gray('\n\
+==========================================================================');
+
+
+function rootCheck() {
+  var msg = chalk.red('Easy with the "sudo"; Yeoman is the master around here.') + '\n\
+Since yo is a user command, there is no need to execute it with superuser\n\
+permissions. If you\'re having permission errors when using yo without sudo,\n\
+please spend a few minutes learning more about how your system should work\n\
+and make any necessary repairs.\n\n\
+http://www.joyent.com/blog/installing-node-and-npm\n\
+https://gist.github.com/isaacs/579814\n';
+
+  sudoBlock({ message: msg });
+}
+
+function init() {
+  var env = require('yeoman-generator')();
+
+  // register each built-in generator individually
+  env.plugins('node_modules', __dirname);
+
+  // alias any single namespace to `*:all` and `webapp` namespace specifically
+  // to webapp:app.
+  env.alias(/^([^:]+)$/, '$1:all');
+  env.alias(/^([^:]+)$/, '$1:app');
+
+  // lookup for every namespaces, within the environments.paths and lookups
+  env.lookup('*:*');
+
+  env.on('end', function () {
+    console.log('Done running sir');
+  });
+
+  env.on('error', function (err) {
+    console.error('Error', process.argv.slice(2).join(' '), '\n');
+    console.error(opts.debug ? err.stack : err.message);
+    process.exit(err.code || 1);
+  });
+
+  // Register the `yo yo` generator.
+  if (!cmd) {
+    if (opts.help) {
+      return console.log(env.help('yo'));
+    }
+
+    env.register(path.resolve(__dirname, './yoyo'), 'yo');
+    args = ['yo'];
+    opts = {};
+  }
+
+  // Note: at some point, nopt needs to know about the generator options, the
+  // one that will be triggered by the below args. Maybe the nopt parsing
+  // should be done internally, from the args.
+  env.run(args, opts);
+}
+
+function pre() {
+  if (opts.version) {
+    return console.log(pkg.version);
+  }
+
+  if (!cmd) {
+    console.log(intro({ supportsColor: chalk.supportsColor }));
+  }
+
+  init();
+}
+
+if (!process.env.yeoman_test && opts.insight !== false) {
+  if (insight.optOut === undefined) {
+    insight.optOut = insight.config.get('optOut');
+    insight.track('downloaded');
+    insight.askPermission(insightMsg, pre);
+    return;
+  }
+  // only track the two first subcommands
+  insight.track.apply(insight, args.slice(0, 2));
+}
+
+if (!process.env.yeoman_test && opts['update-notifier'] !== false) {
+  var notifier = updateNotifier({
+    packagePath: '../package'
+  });
+
+  if (notifier.update) {
+    notifier.notify(true);
+  }
+}
+
+rootCheck();
+pre();

--- a/bin/yo
+++ b/bin/yo
@@ -1,134 +1,52 @@
 #!/usr/bin/env node
-'use strict';
-var fs = require('fs');
+
+/**
+ * This tiny wrapper file checks for known node flags and appends them
+ * when found, before invoking the "real" _yo executable.
+ */
+
+var spawn = require('child_process').spawn;
 var path = require('path');
-var nopt = require('nopt');
-var chalk = require('chalk');
-var _ = require('lodash');
-var pkg = require('../package.json');
-var updateNotifier = require('update-notifier');
-var sudoBlock = require('sudo-block');
-var Insight = require('insight');
+var args = [ path.join(__dirname, '_yo') ];
 
-var opts = nopt({
-  help: Boolean,
-  version: Boolean
-}, {
-  h: '--help',
-  v: '--version'
+process.argv.slice(2).forEach(function (arg) {
+  var flag = arg.split('=')[0];
+
+  switch (flag) {
+    case '-d':
+      args.unshift('--debug');
+      break;
+    case 'debug':
+    case '--debug':
+    case '--debug-brk':
+      args.unshift(arg);
+      break;
+    case '-gc':
+    case '--expose-gc':
+      args.unshift('--expose-gc');
+      break;
+    case '--gc-global':
+    case '--harmony':
+    case '--harmony-proxies':
+    case '--harmony-collections':
+    case '--harmony-generators':
+    case '--prof':
+      args.unshift(arg);
+      break;
+    default:
+      if (0 == arg.indexOf('--trace')) args.unshift(arg);
+      else args.push(arg);
+      break;
+  }
 });
 
-var args = opts.argv.remain;
-var cmd = args[0];
-
-var intro = _.template(fs.readFileSync(path.join(__dirname, 'help.txt'), 'utf8'));
-
-var insight = new Insight({
-  trackingCode: 'UA-31537568-1',
-  packageName: pkg.name,
-  packageVersion: pkg.version
-});
-
-if (opts.insight === false) {
-  insight.config.set('optOut', true);
-} else if (opts.insight) {
-  insight.config.set('optOut', false);
-}
-
-/*jshint multistr:true */
-var insightMsg = chalk.gray('\
-==========================================================================') + chalk.yellow('\n\
-We\'re constantly looking for ways to make ') + chalk.bold.red(pkg.name) + chalk.yellow(' better! \n\
-May we anonymously report usage statistics to improve the tool over time? \n\
-More info: yeoman.io/insight.html & http://yeoman.io') + chalk.gray('\n\
-==========================================================================');
-
-
-function rootCheck() {
-  var msg = chalk.red('Easy with the "sudo"; Yeoman is the master around here.') + '\n\
-Since yo is a user command, there is no need to execute it with superuser\n\
-permissions. If you\'re having permission errors when using yo without sudo,\n\
-please spend a few minutes learning more about how your system should work\n\
-and make any necessary repairs.\n\n\
-http://www.joyent.com/blog/installing-node-and-npm\n\
-https://gist.github.com/isaacs/579814\n';
-
-  sudoBlock({ message: msg });
-}
-
-function init() {
-  var env = require('yeoman-generator')();
-
-  // register each built-in generator individually
-  env.plugins('node_modules', __dirname);
-
-  // alias any single namespace to `*:all` and `webapp` namespace specifically
-  // to webapp:app.
-  env.alias(/^([^:]+)$/, '$1:all');
-  env.alias(/^([^:]+)$/, '$1:app');
-
-  // lookup for every namespaces, within the environments.paths and lookups
-  env.lookup('*:*');
-
-  env.on('end', function () {
-    console.log('Done running sir');
-  });
-
-  env.on('error', function (err) {
-    console.error('Error', process.argv.slice(2).join(' '), '\n');
-    console.error(opts.debug ? err.stack : err.message);
-    process.exit(err.code || 1);
-  });
-
-  // Register the `yo yo` generator.
-  if (!cmd) {
-    if (opts.help) {
-      return console.log(env.help('yo'));
+var proc = spawn(process.argv[0], args, { stdio: [0, 1, 2] });
+proc.on('exit', function (code, signal) {
+  process.on('exit', function () {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code);
     }
-
-    env.register(path.resolve(__dirname, './yoyo'), 'yo');
-    args = ['yo'];
-    opts = {};
-  }
-
-  // Note: at some point, nopt needs to know about the generator options, the
-  // one that will be triggered by the below args. Maybe the nopt parsing
-  // should be done internally, from the args.
-  env.run(args, opts);
-}
-
-function pre() {
-  if (opts.version) {
-    return console.log(pkg.version);
-  }
-
-  if (!cmd) {
-    console.log(intro({ supportsColor: chalk.supportsColor }));
-  }
-
-  init();
-}
-
-if (!process.env.yeoman_test && opts.insight !== false) {
-  if (insight.optOut === undefined) {
-    insight.optOut = insight.config.get('optOut');
-    insight.track('downloaded');
-    insight.askPermission(insightMsg, pre);
-    return;
-  }
-  // only track the two first subcommands
-  insight.track.apply(insight, args.slice(0, 2));
-}
-
-if (!process.env.yeoman_test && opts['update-notifier'] !== false) {
-  var notifier = updateNotifier({
-    packagePath: '../package'
   });
-
-  if (notifier.update) {
-    notifier.notify(true);
-  }
-}
-
-rootCheck();
-pre();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var execFile = require('child_process').execFile;
+var spawn = require('child_process').spawn;
 var assert = require('assert');
 var pkg = require('../package.json');
 var eol = require('os').EOL;
@@ -31,20 +32,11 @@ describe('bin', function () {
     });
 
     it('should exit with status 1 if there were errors', function (cb) {
-      var called = false;
-      process.exit = function (arg) {
-        if (called) {
-          // Exit can be called more than once.
-          return;
-        }
-
-        called = true;
-        assert(arg, 1, 'exit code should be 1');
+      var proc = spawn('node', [path.join(__dirname, '../', pkg.bin.yo), 'notexisting']);
+      proc.on('exit', function (code) {
+        assert(code, 1, 'exit code should be 1');
         cb();
-      };
-      process.argv = ['node', path.join(__dirname, '../', pkg.bin.yo), 'notexisting'];
-      this.env.lookup = function () { /* noop */ };
-      require('../bin/yo');
+      });
     });
   });
 


### PR DESCRIPTION
Refactor `yo` to start a child process running the real yo so that it can pass through node command flags (like `--debug-brk`)

This make it sooooo much nicer for debugging and stepping through generator code.

It have been mostly stolen from the [Mocha repo](https://github.com/visionmedia/mocha/blob/master/bin/mocha) with some adjustment around the stdio so it is inherited.

Now, any generator author can run `yo --debug bbb` (or any other node flags)
