### PR TITLE
Add engineStrict to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "node": ">=0.8.0",
     "npm": ">=1.2.10"
   },
+  "engineStrict": true,
   "preferGlobal": true,
   "licenses": [
     {


### PR DESCRIPTION
This will make it clearer to users why installation fails with unsupported node or npm versions.

Fixes: https://github.com/yeoman/yeoman/issues/1186
