### PR TITLE
remove the mask-worn attribution.

### DIFF
--- a/bin/help.txt
+++ b/bin/help.txt
@@ -41,8 +41,3 @@
     [0m
 
 <% } %>
-Yeoman is a mask worn by the following members of the open-source community:
-
-  Paul Irish, Addy Osmani, Mickael Daniel, Sindre Sorhus, Eric Bidelman,
-  Frederick Ros, Brian Ford, Pascal Hartig, Stephen Sawchuk, and countless
-  other contributors.


### PR DESCRIPTION
I don't think this is entirely necessary. Duplicates whats already on the site and comes before anyone has really used the tool.  Let's keep the onboarding experience swift and easy.  
