### PR TITLE
Rely on the Generator 0.14.0 generator's store

### DIFF
--- a/bin/yoyo.js
+++ b/bin/yoyo.js
@@ -289,7 +289,7 @@ yoyo.prototype.findGenerators = function findGenerators() {
     };
   };
 
-  async.parallel(self._.map(self.env.generators, resolveGenerators), function (err) {
+  async.parallel(self._.map(this.env.getGeneratorsMeta(), resolveGenerators), function (err) {
     if (err) {
       return self.emit('error', err);
     }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "yeoman-generator": "~0.14.0",
+    "yeoman-generator": "~0.14.1",
     "nopt": "~2.1.1",
     "lodash": "~2.2.1",
     "update-notifier": "~0.1.3",


### PR DESCRIPTION
This fix feel somehow slow for me; but I never really used `yo` without directly naming the generator I intend to use. I'd like your opinion. There's a big overhead I think to requiring all available generator. Maybe this could be improved by being able to get a generator meta-data without `require`ing it (e.g. without `this.env.get()`).
