### PR TITLE
Fix generator listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "sudo-block": "~0.3.0",
     "async": "~0.2.9",
     "open": "0.0.4",
-    "chalk": "~0.4.0"
+    "chalk": "~0.4.0",
+    "findup": "~0.1.3"
   },
   "peerDependencies": {
     "grunt-cli": "~0.1.7",


### PR DESCRIPTION
Refactor the way package.json lookup (for update notification) is done.

There was multiple bug with this piece of code. First of all, the regexp where wrong. Second, the check for package.json only worked for generators organized in this fashion:

```
- package.json
   - app/
   - subgenerator/
```

If the generator used other lookup directory, `yo` ignored them from its listing (you could still run it directly `yo bbb`).

That should fix it, plus, it simplify the logic.
