### PR TITLE
Add NPM postinstall script to check potential errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "npm": ">=1.2.10"
   },
   "scripts": {
-    "test": "grunt"
+    "test": "grunt",
+    "postinstall": "node scripts/doctor.js",
+    "postupdate": "node scripts/doctor.js"
   },
   "files": [
     "cli.js",
@@ -42,7 +44,8 @@
     "async": "~0.2.9",
     "open": "0.0.4",
     "chalk": "~0.4.0",
-    "findup": "~0.1.3"
+    "findup": "~0.1.3",
+    "shelljs": "~0.2.6"
   },
   "peerDependencies": {
     "grunt-cli": "~0.1.7",

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -1,0 +1,64 @@
+var chalk = require('chalk');
+var shell = require('shelljs');
+
+var isWin = !!process.platform.match(/^win/);
+var pathSep = isWin ? ';' : ':';
+
+var doctor = {
+  errors: [],
+
+  run: function () {
+    this.checkNodePath();
+
+    this.logErrors();
+  },
+
+  logErrors: function () {
+    if (!this.errors.length) {
+      console.log(chalk.green('[Yeoman Doctor] Everything looks allright!'));
+      console.log();
+      return;
+    }
+    console.log(chalk.red('[Yeoman Doctor] Uh oh, I found potential errors on your machine\n---------------\n'));
+    this.errors.forEach(function (errMsg) {
+      console.log('[' + chalk.red('Error') + '] ' + errMsg);
+      console.log();
+    });
+  },
+
+  checkNodePath: function () {
+    if (!process.env.NODE_PATH) return;
+    var nodePaths = process.env.NODE_PATH.split(pathSep);
+    var npmRoot = shell.exec('npm -g root', { silent: true }).output.replace(/([\r\n])$/, '');
+    if (nodePaths.indexOf(npmRoot) < 0) {
+      this.nodePathMismatch({
+        nodePaths: nodePaths,
+        npmRoot: npmRoot
+      });
+    }
+  },
+
+  nodePathMismatch: function (val) {
+    var output = '';
+    output += 'NPM root value is not in your NODE_PATH\n';
+    output += '  [' + chalk.cyan('info') + ']\n';
+    output += [
+      '    NODE_PATH = ' + val.nodePaths.join(pathSep),
+      '    NPM root  = ' + val.npmRoot
+    ].join('\n');
+    output += '\n\n  [' + chalk.cyan('Fix') + '] Append the NPM root value to your NODE_PATH variable\n';
+
+    if (!isWin) {
+      output += [
+        '    Add this line to your .bashrc',
+        '      export NODE_PATH=$NODE_PATH:' + val.npmRoot,
+        '    Or run this command',
+        '      echo "export NODE_PATH=$NODE_PATH:' + val.npmRoot + '" > ~/.bashrc && source ~/.bashrc'
+      ].join('\n');
+    }
+
+    this.errors.push(output);
+  }
+};
+
+doctor.run();


### PR DESCRIPTION
I added a `doctor` helper to be runned on install script. I believe this is a good place to prompt users for potential errors in their environment.

With `yo@1.0.7`, we got a lot of issues opened with global generators not found because they have a badly setup `NODE_PATH`. Using this hooks to prompt user for potential error should leverage the number of issues opened, and help user found solution faster.

To test it on your machine, simply run `npm link` to launch the script. Then simply `export NODE_PATH=foo` between good and bad values and rerun `link` to check the output.
