### PR TITLE
package.json license should match readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yo",
   "version": "1.1.2",
   "description": "CLI tool for scaffolding out Yeoman projects",
-  "license": "MIT",
+  "license": "BSD",
   "bin": {
     "yo": "cli.js"
   },


### PR DESCRIPTION
Presumably, the readme is correct (BSD). The majority of the yeoman
utilities are all BSD so I'm assuming yo is as well, despite
package.json stating MIT.
