### PR TITLE
Add ability to update a single generator

### DIFF
--- a/test/yoyo.js
+++ b/test/yoyo.js
@@ -83,6 +83,7 @@ describe('yo yo', function () {
   describe('updateGenerators', function () {
     var pkgs = yoyo.prototype.pkgs;
     var updatedGenerators = [];
+    var choices = [];
     var sentHome = false;
 
     beforeEach(function () {
@@ -114,14 +115,21 @@ describe('yo yo', function () {
         sentHome = true;
       });
 
-      yoyo.prototype._updateGenerators();
+      helpers.stub(yoyo.prototype, 'prompt', function (prompts) {
+        prompts[0].choices.forEach(function (choice) {
+          choices.push(choice);
+        });
+        yoyo.prototype._updateGenerators(choices.map(function (choice) { return choice.name; }));
+      });
+
+      yoyo.prototype._promptToUpdateGenerators();
     });
 
     after(function () {
       yoyo.prototype.pkgs = pkgs;
     });
 
-    it('should globally update installed generators', function () {
+    it('should globally update selected generators', function () {
       assert.ok(updatedGenerators.indexOf('generator-unicorn') > -1);
       assert.ok(updatedGenerators.indexOf('generator-phoenix') > -1);
     });


### PR DESCRIPTION
This adds an option to update a single generator,  currently it displays a list of generators to choose from.

Not sure if this should be a checkbox instead of a just "choose one".  This sort of relates to https://github.com/yeoman/yo/issues/142
