### PR TITLE
Fix spelling of "all right".

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -12,7 +12,7 @@ var doctor = module.exports = {
 
   logErrors: function () {
     if (!this.errors.length) {
-      console.log(chalk.green('[Yeoman Doctor] Everything looks alright!'));
+      console.log(chalk.green('[Yeoman Doctor] Everything looks all right!'));
       console.log();
       return;
     }


### PR DESCRIPTION
"Alright" is nonstandard and usually considered incorrect (though it's certainly a common error). "All right" is the correct spelling. See http://www.oxforddictionaries.com/us/definition/american_english/all-right .
