### PR TITLE
Switch from npm update to npm install.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -153,7 +153,7 @@ if (!process.env.yeoman_test && opts['update-notifier'] !== false) {
 
   if (notifier.update) {
     message.push('Update available: ' + chalk.green.bold(notifier.update.latest) + chalk.gray(' (current: ' + notifier.update.current + ')'));
-    message.push('Run ' + chalk.magenta('npm update -g ' + pkg.name) + ' to update.');
+    message.push('Run ' + chalk.magenta('npm install -g ' + pkg.name) + ' to update.');
     console.log(yosay(message.join(' '), { maxLength: stringLength(message[0]) }));
   }
 }

--- a/yoyo.js
+++ b/yoyo.js
@@ -34,13 +34,13 @@ var yoyo = module.exports = function (args, options) {
 util.inherits(yoyo, gen.Base);
 
 
-// Runs parallel `npm update -g`s for each selected generator.
+// Runs parallel `npm install -g`s for each selected generator.
 yoyo.prototype._updateGenerators = function (pkgs) {
   var self = this;
 
   var resolveGenerators = function (pkg) {
     return function (next) {
-      self.spawnCommand('npm', ['update', '-g', pkg])
+      self.spawnCommand('npm', ['install', '-g', pkg])
         .on('error', next)
         .on('exit', next);
     };
@@ -60,7 +60,7 @@ yoyo.prototype._updateGenerators = function (pkgs) {
       message:
         'I\'ve just updated your generators. Remember, you can update' +
         '\na specific generator with npm by running:\n' +
-        chalk.magenta('\n    npm update -g generator-_______')
+        chalk.magenta('\n    npm install -g generator-_______')
     });
   });
 };


### PR DESCRIPTION
npm update doesn't do what you think it does: It updates all internal
dependencies of each package, as a maintainer would do when testing new
versions to update their `package.json`; it doesn't refresh just the
specified package, but the things within it.

`npm install` actually does the right thing, upgrading to the `@latest`
tagged version of the package.
