### PR TITLE
Include options from readme.md in usage.txt so output with _yo --help_

### DIFF
--- a/lib/usage.txt
+++ b/lib/usage.txt
@@ -1,5 +1,11 @@
 Usage: yo GENERATOR [args] [options]
 
 General options:
-  -h, --help     # Print generator's options and usage
+  -h 		 # Enter interactive help menu
+  --help     	 # Print this info and generator's options and usage
   -f, --force    # Overwrite files that already exist
+  --version	 # Print Yo's version
+  --no-color	 # flag to disable colors.
+  --[no-]insight # toggle anonymous tracking
+  --generators	 # will output the available generators
+  


### PR DESCRIPTION
The yo options, as defined in the _readme.md_, were not available via the `--help` output.
Updated the usage.txt to cover the options mentioned there, and to clarify the difference between `-h` and `--help`.

Updated output now looks like this;
```
Usage: yo GENERATOR [args] [options]

General options:
  -h 		     # Enter interactive help menu
  --help     	 # Print this info and generator's options and usage
  -f, --force    # Overwrite files that already exist
  --version	     # Print Yo's version
  --no-color	 # flag to disable colors.
  --[no-]insight # toggle anonymous tracking
  --generators	 # will output the available generators
```