### PR TITLE
Correct typo on line 36 in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ Running `yo doctor` command can help you troubleshoot common issues.
 
 If `doctor` doesn't help, then check opened issues for a similar problem. Open a new issue if your problem haven't been reported yet. Make sure to always include the version of `yo` (`yo --version`) and Node.js (`node --version`) you use.
 
-If your issue only occur using a generator, please report the issues on the generator's repository.
+If your issue only occurs using a generator, please report the issues on the generator's repository.
 
 
 ## Contribute


### PR DESCRIPTION


Line 36 before correction:
If your issue only occur after using a generator...

Line 36 after correction:
If your issue only occur<b>s</b> after using a generator...

'Occur' needed to be made plural.
![yo_screenshot2](https://cloud.githubusercontent.com/assets/8481896/7740936/5a1dd41e-ff2d-11e4-8cb9-f07bdcc080ae.jpg)
![yo_screenshot1](https://cloud.githubusercontent.com/assets/8481896/7740937/5f06f866-ff2d-11e4-9f2d-5b9023dd0092.jpg)


