### PR TITLE
Fixed the name output for generators in --help (Closes #334)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -80,7 +80,9 @@ function init() {
       if (opts.help) {
         var genList = Object.keys(env.getGeneratorsMeta()).map(function (el) {
           var parts = el.split(':');
-          return '  ' + (parts[1] === 'app' ? parts[0] : '  ' + parts[1]);
+          var first = parts.shift();
+          return '  ' + (parts[0] === 'app' ? first : '  ' + parts.join(':'));
+          
         }).join('\n');
 
         console.log(fs.readFileSync(path.join(__dirname, 'usage.txt'), 'utf8') + '\nAvailable Generators:\n' + genList);


### PR DESCRIPTION
### Problem:
I encountered an issue with `--help`. It slices off any parts of a subgenerator name which come after a colon. 

**closes: #334**

### Solution:
I simply remove the first element of the array and then recombine it in the output instead of using the second part explicitly. See the commit for implementation.