### PR TITLE
update license

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yo",
   "version": "1.4.6",
   "description": "CLI tool for running Yeoman generators",
-  "license": "BSD",
+  "license": "MIT",
   "bin": "lib/cli.js",
   "author": "Yeoman",
   "repository": "yeoman/yo",


### PR DESCRIPTION
due to npm@v2.10

"BSD" is not valid SPDX identifier, `license` file in repo says MIT, soo.. The actual is MIT?

http://spdx.org/licenses/
https://npm1k.org/
https://github.com/npm/npm/releases/tag/v2.10.0