### PR TITLE
Change the separator color text

### DIFF
--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -65,7 +65,7 @@ module.exports = function (app) {
       type: 'list',
       message: allo + 'What would you like to do?',
       choices: _.flatten([
-        new inquirer.Separator('Run a generator'),
+        new inquirer.Separator(chalk.dim.grey('Run a generator')),
         generatorList,
         new inquirer.Separator(),
         defaultChoices,


### PR DESCRIPTION
Just to make it more obvious its not selectable.

Before: 
![screen shot 2015-06-22 at 4 29 03 pm](https://cloud.githubusercontent.com/assets/6316590/8276956/49b227e6-1900-11e5-8614-d89d7713c5ae.png)


After:
![screen shot 2015-06-22 at 4 58 17 pm](https://cloud.githubusercontent.com/assets/6316590/8276957/4d337a82-1900-11e5-8d22-1a6ae0c394d7.png)


My instinct always told me that "Run a generator" was selectable and I ended up selecting "Get me out of here!" :cry: 
This change makes it very clear that "Run a generator" is not selectable and it's obviously a part of the separator.
https://github.com/SBoudrias/Inquirer.js/pull/252
@SBoudrias I assume this is what you mean by "overwrite"?