### PR TITLE
Initialize multiple generators with one command.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,28 +9,33 @@ var yosay = require('yosay');
 var stringLength = require('string-length');
 var rootCheck = require('root-check');
 var meow = require('meow');
+var list = require('cli-list');
 var pkg = require('../package.json');
 var Router = require('./router');
 
-var cli = meow({
-  help: false,
-  pkg: pkg
-});
+var gens = list(process.argv.slice(2));
 
-var opts = cli.flags;
-var args = cli.input;
-var cmd = args[0];
-var insight;
+var cli = gens.map(function (gen) {
+  var minicli = meow({ help: false, pkg: pkg, argv: gen });
+  var opts = minicli.flags;
+  var args = minicli.input;
 
-// add un-camelized options too, for legacy
-// TODO: remove some time in the future when generators have upgraded
-Object.keys(opts).forEach(function (key) {
-  var legacyKey = key.replace(/[A-Z]/g, function (m) {
-    return '-' + m.toLowerCase();
+  // add un-camelized options too, for legacy
+  // TODO: remove some time in the future when generators have upgraded
+  Object.keys(opts).forEach(function (key) {
+    var legacyKey = key.replace(/[A-Z]/g, function (m) {
+      return '-' + m.toLowerCase();
+    });
+
+    opts[legacyKey] = opts[key];
   });
 
-  opts[legacyKey] = opts[key];
+  return { opts: opts, args: args };
 });
+
+var firstCmd = cli[0] || { opts: {}, args: {} };
+var cmd = firstCmd.args[0];
+var insight;
 
 function updateCheck() {
   var notifier = updateNotifier({pkg: pkg});
@@ -93,7 +98,7 @@ function init() {
 
   env.on('error', function (err) {
     console.error('Error', process.argv.slice(2).join(' '), '\n');
-    console.error(opts.debug ? err.stack : err.message);
+    console.error(firstCmd.opts.debug ? err.stack : err.message);
     process.exit(err.code || 1);
   });
 
@@ -102,14 +107,14 @@ function init() {
     var generatorList = createGeneratorList(env);
 
     // list generators
-    if (opts.generators) {
+    if (firstCmd.opts.generators) {
       console.log('Available Generators:\n\n' + generatorList);
       return;
     }
 
     // start the interactive UI if no generator is passed
     if (!cmd) {
-      if (opts.help) {
+      if (firstCmd.opts.help) {
         var usageText = fs.readFileSync(path.join(__dirname, 'usage.txt'), 'utf8');
         console.log(usageText + '\nAvailable Generators:\n\n' + generatorList);
         return;
@@ -122,7 +127,9 @@ function init() {
     // Note: at some point, nopt needs to know about the generator options, the
     // one that will be triggered by the below args. Maybe the nopt parsing
     // should be done internally, from the args.
-    env.run(args, opts);
+    cli.forEach(function (gen) {
+      env.run(gen.args, gen.opts);
+    });
   });
 }
 
@@ -158,20 +165,20 @@ insight = new Insight({
   pkg: pkg
 });
 
-if (opts.insight === false) {
+if (firstCmd.opts.insight === false) {
   insight.config.set('optOut', true);
-} else if (opts.insight) {
+} else if (firstCmd.opts.insight) {
   insight.config.set('optOut', false);
 }
 
-if (opts.insight !== false && insight.optOut === undefined) {
+if (firstCmd.opts.insight !== false && insight.optOut === undefined) {
   insight.optOut = insight.config.get('optOut');
   insight.track('downloaded');
   insight.askPermission(insightMsg, pre);
 } else {
-  if (opts.insight !== false) {
+  if (firstCmd.opts.insight !== false) {
     // only track the two first subcommands
-    insight.track.apply(insight, args.slice(0, 2));
+    insight.track.apply(insight, firstCmd.args.slice(0, 2));
   }
 
   updateCheck();

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "async": "^1.0.0",
     "chalk": "^1.0.0",
+    "cli-list": "^0.1.1",
     "configstore": "^1.0.0",
     "cross-spawn-async": "^2.0.0",
     "figures": "^1.3.5",


### PR DESCRIPTION
This PR makes it so you can initialize multiple generators in the same environment with one command, using a comma `,` as the delimiter between them:

```shell
$ yo express, angular app-name, devjs:babel
```
This way you can still use options and arguments, alongside using multiple generators.

Following generators are canceled if it is special usage. For instance, these `node` generators do not run, but the first task is still done:
```
$ yo doctor, node
```
```
$ yo --version, node
```
```
$ yo --generators, node
```

Closes #413