### PR TITLE
Yo completion

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,8 +14,7 @@ var pkg = require('../package.json');
 var Router = require('./router');
 var tabtab = new (require('tabtab').Commands.default)({
   name: 'yo',
-  completer: 'yo-complete',
-  cache: false
+  completer: 'yo-complete'
 });
 
 var gens = list(process.argv.slice(2));

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,6 +12,11 @@ var meow = require('meow');
 var list = require('cli-list');
 var pkg = require('../package.json');
 var Router = require('./router');
+var tabtab = new (require('tabtab').Commands.default)({
+  name: 'yo',
+  completer: 'yo-complete',
+  cache: false
+});
 
 var gens = list(process.argv.slice(2));
 
@@ -53,6 +58,10 @@ function pre() {
   if (cmd === 'doctor') {
     require('yeoman-doctor')();
     return;
+  }
+
+  if (cmd === 'completion') {
+    return tabtab.install();
   }
 
   // easteregg

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,12 +12,13 @@ var meow = require('meow');
 var list = require('cli-list');
 var pkg = require('../package.json');
 var Router = require('./router');
+var gens = list(process.argv.slice(2));
+
+/* eslint new-cap: 0, no-extra-parens: 0 */
 var tabtab = new (require('tabtab').Commands.default)({
   name: 'yo',
   completer: 'yo-complete'
 });
-
-var gens = list(process.argv.slice(2));
 
 var cli = gens.map(function (gen) {
   var minicli = meow({ help: false, pkg: pkg, argv: gen });

--- a/lib/usage.txt
+++ b/lib/usage.txt
@@ -15,6 +15,12 @@ Install a generator:
   $ npm install generator-angular
   $ yo angular --help
 
+Completion:
+
+  To enable shell completion for the yo command, try running
+
+  $ yo completion
+
 Troubleshooting:
 
   For any issues, try running

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "test": "gulp",
     "postinstall": "yodoctor && npm run tabtab",
     "postupdate": "yodoctor",
-    "prepublish": "gulp prepublish",
-    "tabtab": "[ $CI ] || tabtab install --name=yo --completer=yo-complete"
+    "prepublish": "gulp prepublish"
   },
   "dependencies": {
     "async": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "test": "gulp",
-    "postinstall": "yodoctor && npm run tabtab",
+    "postinstall": "yodoctor",
     "postupdate": "yodoctor",
     "prepublish": "gulp prepublish"
   },


### PR DESCRIPTION
Related to #430 #432 

This PR moves the `tabtab install` part behind `yo completion`. This is far less obstrusive than doing it on npm install, and would impact only users that want to test out yeoman completion.

The downside is that it prevents anyone from using a generator named `completion`, but I guess it is not a big deal (would be a weird name :d).

It might be good to update the documentation or site to document it along other special keywords / commands like `yo doctor`.

I've also updated the `--help` output to include this new command.