### PR TITLE
Completion: Silent install, better handling of descriptions

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -13,9 +13,8 @@ var list = require('cli-list');
 var pkg = require('../package.json');
 var Router = require('./router');
 var gens = list(process.argv.slice(2));
-
-/* eslint new-cap: 0, no-extra-parens: 0 */
-var tabtab = new (require('tabtab').Commands.default)({
+var TabtabCommands = require('tabtab').Commands;
+var tabtab = new TabtabCommands({
   name: 'yo',
   completer: 'yo-complete'
 });

--- a/lib/completion/completer.js
+++ b/lib/completion/completer.js
@@ -1,10 +1,5 @@
 'use strict';
 
-var path = require('path');
-var execFile = require('child_process').execFile;
-var parseHelp = require('parse-help');
-var assign = require('lodash').assign;
-
 /**
  * The Completer is in charge of handling `yo-complete` behavior.
  * @constructor
@@ -21,7 +16,10 @@ var Completer = module.exports = function (env) {
  * @param {Function} done   Callback to invoke with completion results
  */
 Completer.prototype.complete = function (data, done) {
-  if (data.last !== 'yo' && !/^-/.test(data.last)) {
+  var last = data.last.trim();
+
+  // Completing on `yo generator <tab>`
+  if (!last && data.prev !== 'yo') {
     return this.generator(data, done);
   }
 
@@ -31,37 +29,30 @@ Completer.prototype.complete = function (data, done) {
     }
 
     var meta = this.env.getGeneratorsMeta();
-    var results = Object.keys(meta).map(this.item('yo'), this);
+    var results = this.metaItems(meta);
     done(null, results);
   }.bind(this));
 };
 
 
 /**
- * Generator completion event done
+ * Invoked when tabbing after a yeoman generator.
+ *
+ * noop for the moment, invoking `--help` is too slow and / or unreliable
  *
  * @param {String}   data   Environment object as parsed by tabtab
  * @param {Function} done   Callback to invoke with completion results
  */
 Completer.prototype.generator = function (data, done) {
-  var last = data.last;
-  var bin = path.join(__dirname, '../cli.js');
-
-  execFile('node', [bin, last, '--help'], function (err, out) {
-    if (err) {
-      return done(err);
-    }
-
-    var results = this.parseHelp(last, out);
-    done(null, results);
-  }.bind(this));
+  // noop: see if we can require / inspect generators options / arguments
+  return done(null, []);
 };
 
 /**
  * Helper to format completion results into { name, description } objects
  *
- * @param {String}   data   Environment object as parsed by tabtab
- * @param {Function} done   Callback to invoke with completion results
+ * @param {String}  desc    When defined, can be used to set a static description
+ * @param {String}  prefix  Used to prefix completion results (ex: --)
  */
 Completer.prototype.item = function (desc, prefix) {
   prefix = prefix || '';
@@ -80,28 +71,20 @@ Completer.prototype.item = function (desc, prefix) {
 };
 
 /**
- * parse-help wrapper. Invokes parse-help with stdout result, returning the
- * list of completion items for flags / alias.
+ * Helper to format completion results for generator meta result into { name, description } objects
  *
- * @param {String}   last  Last word in COMP_LINE (completed line in command line)
- * @param {String}   out   Help output
+ * @param {String}  desc    When defined, can be used to set a static description
  */
-Completer.prototype.parseHelp = function (last, out) {
-  var help = parseHelp(out);
-  var alias = [];
-  var results = Object.keys(help.flags).map(function (key) {
-    var flag = help.flags[key];
-    if (flag.alias) {
-      alias.push(assign({}, flag, { name: flag.alias }));
-    }
-    flag.name = key;
-    return flag;
-  }).map(this.item(last, '--'), this);
+Completer.prototype.metaItems = function (metas) {
+  return Object.keys(metas).map(function (key) {
+    var meta = metas[key];
+    var parts = meta.namespace.split(':');
+    var generator = parts[0];
+    var subgenerator = parts.slice(1);
 
-  results = results.concat(alias.map(this.item(last.replace(':', '_'), '-'), this));
-  results = results.filter(function (r) {
-    return r.name !== '--help' && r.name !== '-h';
+    return {
+      name: key,
+      description: subgenerator + ' from ' + generator + ' generator'
+    };
   });
-
-  return results;
 };

--- a/lib/usage.txt
+++ b/lib/usage.txt
@@ -17,7 +17,7 @@ Install a generator:
 
 Completion:
 
-  To enable shell completion for the yo command, try running
+  Run the following to enable shell completion
 
   $ yo completion
 

--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
   },
   "scripts": {
     "test": "gulp",
-    "postinstall": "yodoctor",
+    "postinstall": "yodoctor && tabtab install --auto --name=yo --completer=yo-complete",
     "postupdate": "yodoctor",
-    "prepublish": "gulp prepublish"
+    "prepublish": "gulp prepublish",
+    "postuninstall": "tabtab uninstall --auto"
   },
   "dependencies": {
     "async": "^1.0.0",
@@ -57,13 +58,12 @@
     "npm-keyword": "^4.1.0",
     "opn": "^3.0.2",
     "package-json": "^2.1.0",
-    "parse-help": "^0.1.1",
     "read-pkg-up": "^1.0.1",
     "repeating": "^2.0.0",
     "root-check": "^1.0.0",
     "sort-on": "^1.0.0",
     "string-length": "^1.0.0",
-    "tabtab": "^1.3.0",
+    "tabtab": "^1.4.2",
     "titleize": "^1.0.0",
     "update-notifier": "^0.6.0",
     "user-home": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "root-check": "^1.0.0",
     "sort-on": "^1.0.0",
     "string-length": "^1.0.0",
-    "tabtab": "^1.4.2",
+    "tabtab": "1.4.x",
     "titleize": "^1.0.0",
     "update-notifier": "^0.6.0",
     "user-home": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "root-check": "^1.0.0",
     "sort-on": "^1.0.0",
     "string-length": "^1.0.0",
-    "tabtab": "1.4.x",
+    "tabtab": "mklabs/node-tabtab",
     "titleize": "^1.0.0",
     "update-notifier": "^0.6.0",
     "user-home": "^2.0.0",

--- a/test/completion.js
+++ b/test/completion.js
@@ -17,13 +17,11 @@ describe('Completion', function () {
       var cmd = 'DEBUG="tabtab*" SHELL=zsh COMP_POINT="4" COMP_LINE="yo" COMP_CWORD="yo" ';
       cmd += 'node lib/completion/index.js completion -- yo';
 
-      console.log('cmd', cmd);
       execFile('bash', ['-c', cmd], function (err, out) {
         if (err) {
           return done(err);
         }
 
-        console.log('out:', out);
         assert.ok(/-f/.test(out));
         assert.ok(/--force/.test(out));
         assert.ok(/--version/.test(out));

--- a/test/completion.js
+++ b/test/completion.js
@@ -1,29 +1,10 @@
 'use strict';
-
-var path = require('path');
 var assert = require('assert');
 var events = require('events');
 var execFile = require('child_process').execFile;
 var Completer = require('../lib/completion/completer');
 var completion = require('../lib/completion');
 var find = require('lodash').find;
-
-var help = [
-  '  Usage:',
-  '  yo backbone:app [options] [<app_name>]',
-  '',
-  '  Options:',
-  '    -h,   --help                # Print the generator\'s options and usage',
-  '          --skip-cache          # Do not remember prompt answers                         Default: false',
-  '          --skip-install        # Do not automatically install dependencies              Default: false',
-  '          --appPath             # Name of application directory                          Default: app',
-  '          --requirejs           # Support requirejs                                      Default: false',
-  '          --template-framework  # Choose template framework. lodash/handlebars/mustache  Default: lodash',
-  '          --test-framework      # Choose test framework. mocha/jasmine                   Default: mocha',
-  '',
-  '  Arguments:',
-  '    app_name    Type: String  Required: false'
-].join('\n');
 
 describe('Completion', function () {
 
@@ -33,17 +14,16 @@ describe('Completion', function () {
 
   describe('Test completion STDOUT output', function () {
     it('Returns the completion candidates for both options and installed generators', function (done) {
-      var yocomplete = path.join(__dirname, '../lib/completion/index.js');
-      var yo = path.join(__dirname, '../lib/cli');
+      var cmd = 'DEBUG="tabtab*" SHELL=zsh COMP_POINT="4" COMP_LINE="yo" COMP_CWORD="yo" ';
+      cmd += 'node lib/completion/index.js completion -- yo';
 
-      var cmd = 'export cmd=\"yo\" && DEBUG=\"tabtab*\" COMP_POINT=\"4\" COMP_LINE=\"$cmd\" COMP_CWORD=\"$cmd\"';
-      cmd += 'node ' + yocomplete + ' completion -- ' + yo + ' $cmd';
-
+      console.log('cmd', cmd);
       execFile('bash', ['-c', cmd], function (err, out) {
         if (err) {
           return done(err);
         }
 
+        console.log('out:', out);
         assert.ok(/-f/.test(out));
         assert.ok(/--force/.test(out));
         assert.ok(/--version/.test(out));
@@ -69,7 +49,7 @@ describe('Completion', function () {
       // instance directly to completer.
       this.getGeneratorsMeta = this.env.getGeneratorsMeta;
 
-      this.env.getGeneratorsMeta =  function () {
+      this.env.getGeneratorsMeta = function () {
         return {
           'dummy:app': {
             resolved: '/home/user/.nvm/versions/node/v6.1.0/lib/node_modules/generator-dummy/app/index.js',
@@ -87,19 +67,6 @@ describe('Completion', function () {
 
     afterEach(function () {
       this.env.getGeneratorsMeta = this.getGeneratorsMeta;
-    });
-
-    describe('#parseHelp', function () {
-      it('Returns completion items based on help output', function () {
-        var results = this.completer.parseHelp('backbone:app', help);
-        var first = results[0];
-
-        assert.equal(results.length, 6);
-        assert.deepEqual(first, {
-          name: '--skip-cache',
-          description: 'Do not remember prompt answers                         Default-> false'
-        });
-      });
     });
 
     describe('#item', function () {
@@ -126,27 +93,6 @@ describe('Completion', function () {
       });
     });
 
-    describe('#generator', function () {
-      it('Returns completion candidates from generator help output', function (done) {
-        // Here we test against yo --help (could use dummy:yo --help)
-        this.completer.complete({ last: '' }, function (err, results) {
-          if (err) {
-            return done(err);
-          }
-
-          /* eslint no-multi-spaces: 0 */
-          assert.deepEqual(results, [
-            { name: '--force',    description: 'Overwrite files that already exist' },
-            { name: '--version',  description: 'Print version' },
-            { name: '--no-color', description: 'Disable colors' },
-            { name: '-f',         description: 'Overwrite files that already exist' }
-          ]);
-
-          done();
-        });
-      });
-    });
-
     describe('#complete', function () {
       it('Returns the list of user installed generators as completion candidates', function (done) {
         this.completer.complete({ last: 'yo' }, function (err, results) {
@@ -159,7 +105,7 @@ describe('Completion', function () {
           });
 
           assert.equal(dummy.name, 'dummy:yo');
-          assert.equal(dummy.description, 'yo');
+          assert.equal(dummy.description, 'yo from dummy generator');
 
           done();
         });


### PR DESCRIPTION
Follow up to the completion feature.

This PR tries to implement what we discussed before, and fix a few issues we had for bash / zsh shell (https://github.com/mklabs/node-tabtab/issues/21)

- I update tabtab to handle a new flag `--auto` for both `install / uninstall`. It'll use the shell configuration file without prompting user for a decision. It goes in pair with `tabtab uninstall --auto`
  - Doing so, `npm i yo -g` and `npm uninstall yo -g` will automatically update the SHELL configuration file (~/.bashrc, ~/.zshrc or ~/.config/fish/config.fish). This should be totally transparent.

- Fixed bad zsh / bash behavior with cache

- Implemented zsh description for completion items, a bit like fish. 

```text
$ yo <tab>
--force              -- description for --force
--generators         -- description for --generators
--insight            -- description for --insight
--no-color           -- description for --no-color
--no-insight         -- description for --no-insight
--version            -- description for --version
-f                   -- description for -f
backbone:all         -- all from backbone generator
backbone:app         -- app from backbone generator
backbone:collection  -- collection from backbone generator
backbone:model       -- model from backbone generator
backbone:router      -- router from backbone generator
backbone:view        -- view from backbone generator
jekyllrb:app         -- app from jekyllrb generator
jekyllrb:post        -- post from jekyllrb generator
react:app            -- app from react generator

```

- Removed `yo generator <tab>` completion where we try to parse the help output. I got a lot of issues with it, and decided to put it aside for the moment. Plus, the  `--help` output exec is really slow and not ideal. I'm thinking about trying to require the generator and try to see if I can inspect the options / arguments hash.

---

Question: While implementing descriptions, I wondered what we should set as description for flags and generators. For now I went for `%subgenerator from %name generator`, if you can think of something better :+1: 