### PR TITLE
Get the real repository source to update the generator

### DIFF
--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -16,8 +16,19 @@ function updateSuccess(app) {
   });
 }
 
+function getPackageGit(generators, pkgs) {
+  var repository = generators[pkgs] ? generators[pkgs].repository : null;
+  if (!repository || !repository.url) {
+    return pkgs;
+  }
+  if (typeof repository === 'string') {
+    return repository;
+  }
+  return repository.type ? [repository.type, repository.url].join('+') : repository.url;
+}
+
 function updateGenerators(app, pkgs) {
-  spawn('npm', ['install', '-g'].concat(pkgs), {stdio: 'inherit'})
+  spawn('npm', ['install', '-g'].concat(getPackageGit(app.generators || {}, pkgs)), {stdio: 'inherit'})
     .on('close', updateSuccess.bind(null, app));
 }
 

--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -17,14 +17,17 @@ function updateSuccess(app) {
 }
 
 function getPackageGit(generators, pkgs) {
-  var repository = generators[pkgs] ? generators[pkgs].repository : null;
-  if (!repository || !repository.url) {
-    return pkgs;
-  }
-  if (typeof repository === 'string') {
-    return repository;
-  }
-  return repository.type ? [repository.type, repository.url].join('+') : repository.url;
+  pkgs = Object.prototype.toString.call(pkgs) === '[object Array]' ? pkgs : [pkgs];
+  return pkgs.map(function (pkg) {
+    var repository = generators[pkg] ? generators[pkg].repository : null;
+    if (typeof repository === 'string') {
+      return repository;
+    }
+    if (!repository || !repository.url) {
+      return pkg;
+    }
+    return repository.type ? [repository.type, repository.url].join('+') : repository.url;
+  });
 }
 
 function updateGenerators(app, pkgs) {

--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -16,8 +16,8 @@ function updateSuccess(app) {
   });
 }
 
-function getPackageGit(generators, pkgs) {
-  pkgs = Object.prototype.toString.call(pkgs) === '[object Array]' ? pkgs : [pkgs];
+function getGitRepositoryFromPackageJson(generators, pkgs) {
+  pkgs = [].concat(pkgs);
   return pkgs.map(function (pkg) {
     var repository = generators[pkg] ? generators[pkg].repository : null;
     if (typeof repository === 'string') {
@@ -31,7 +31,7 @@ function getPackageGit(generators, pkgs) {
 }
 
 function updateGenerators(app, pkgs) {
-  spawn('npm', ['install', '-g'].concat(getPackageGit(app.generators || {}, pkgs)), {stdio: 'inherit'})
+  spawn('npm', ['install', '-g'].concat(getGitRepositoryFromPackageJson(app.generators || {}, pkgs)), {stdio: 'inherit'})
     .on('close', updateSuccess.bind(null, app));
 }
 

--- a/test/route-update.js
+++ b/test/route-update.js
@@ -32,9 +32,63 @@ describe('update route', function () {
     this.sandbox.stub(inquirer, 'prompt', function (arg, cb) {
       cb({generators: generators});
     });
+
     this.router.navigate('update');
 
     sinon.assert.calledWith(this.crossSpawn, 'npm', ['install', '-g'].concat(generators));
+    sinon.assert.calledWith(this.insight.track, 'yoyo', 'update');
+    sinon.assert.calledWith(this.insight.track, 'yoyo', 'updated');
+    sinon.assert.calledOnce(this.homeRoute);
+    sinon.assert.calledOnce(this.env.lookup);
+  });
+
+  it('allows updating generators from a custom source (type + url)', function () {
+    var generatorData = {
+      'generator-cat': {
+        repository: {
+          type: 'git',
+          url: 'generator-cat'
+        }
+      }
+    };
+    this.router.generators = generatorData;
+    var generators = Object.keys(generatorData);
+    this.sandbox.stub(inquirer, 'prompt', function (arg, cb) {
+      cb({generators: generators});
+    });
+
+    var uris = generators.map(function (generator) {
+      return [generatorData[generator].repository.type, generatorData[generator].repository.url].join('+');
+    });
+
+    this.router.navigate('update');
+
+    sinon.assert.calledWith(this.crossSpawn, 'npm', ['install', '-g'].concat(uris));
+    sinon.assert.calledWith(this.insight.track, 'yoyo', 'update');
+    sinon.assert.calledWith(this.insight.track, 'yoyo', 'updated');
+    sinon.assert.calledOnce(this.homeRoute);
+    sinon.assert.calledOnce(this.env.lookup);
+  });
+
+  it('allows updating generators from a custom source (repository)', function () {
+    var generatorData = {
+      'generator-cat': {
+        repository: 'This-is-the-source'
+      }
+    };
+    this.router.generators = generatorData;
+    var generators = Object.keys(generatorData);
+    this.sandbox.stub(inquirer, 'prompt', function (arg, cb) {
+      cb({generators: generators});
+    });
+
+    var uris = generators.map(function (generator) {
+      return generatorData[generator].repository;
+    });
+
+    this.router.navigate('update');
+
+    sinon.assert.calledWith(this.crossSpawn, 'npm', ['install', '-g'].concat(uris));
     sinon.assert.calledWith(this.insight.track, 'yoyo', 'update');
     sinon.assert.calledWith(this.insight.track, 'yoyo', 'updated');
     sinon.assert.calledOnce(this.homeRoute);


### PR DESCRIPTION
In my company, we are using yo. I developped internal generators (only valid for my company, that's why I cannot share on github)
With this modification, when updating, the exact source of the repository (if specified) is used to update the package