### PR TITLE
Cancel npm install if no generators are selected to update 

### DIFF
--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -27,6 +27,9 @@ module.exports = function (app) {
     name: 'generators',
     message: 'Generators to update',
     type: 'checkbox',
+    validate: function (input) {
+      return input.length > 0 ? true : 'Please select at least one generator to update.';
+    },
     choices: Object.keys(app.generators || {}).map(function (key) {
       return {
         name: app.generators[key].name,


### PR DESCRIPTION
This PR attempts to fix the bug pointed out here https://github.com/yeoman/yo/issues/469 , which is the unwanted behavior that the cli will run `npm install -g` if no generators are selected. 