### PR TITLE
Drop v.12 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - v0.12
   - v4
   - v5
   - v6


### PR DESCRIPTION
`node v.12` is being left for EOL now and I don't see any reason to keep it supported in Travis. Merge is optional!

## Purpose of this pull request 

- [x] Enhancement
