### PR TITLE
Update `fullname` package to fix npm warn

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "configstore": "^1.0.0",
     "cross-spawn": "^3.0.1",
     "figures": "^1.3.5",
-    "fullname": "^2.0.0",
+    "fullname": "^3.2.0",
     "got": "^5.0.0",
     "humanize-string": "^1.0.0",
     "inquirer": "^1.0.2",


### PR DESCRIPTION
<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/yeoman/blob/master/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [x] Enhancement
- [ ] Other, please explain:

## What changes did you make?

<!-- Give an overview -->
Update `fullname` package to fix npm warn:
```
npm WARN deprecated npmconf@2.1.2: this package has been reintegrated into npm and is now out of date with respect to npm
```

## Is there anything you'd like reviewers to focus on?

<!-- Just in case -->
