### PR TITLE
Fix npm search

### DIFF
--- a/lib/routes/install.js
+++ b/lib/routes/install.js
@@ -41,13 +41,13 @@ module.exports = app => {
 };
 
 const generatorMatchTerm = (generator, term) => `${generator.name} ${generator.description}`.indexOf(term) !== -1;
-const getAllGenerators = _.memoize(() => npmKeyword('yeoman-generator'));
+const getGenerators = _.memoize(term => npmKeyword(['yeoman-generator', term]));
 
 function searchMatchingGenerators(app, term, cb) {
   function handleBlacklist(blacklist) {
     const installedGenerators = app.env.getGeneratorNames();
 
-    getAllGenerators().then(allGenerators => {
+    getGenerators(term).then(allGenerators => {
       cb(null, allGenerators.filter(generator => {
         if (blacklist.indexOf(generator.name) !== -1) {
           return false;

--- a/lib/routes/install.js
+++ b/lib/routes/install.js
@@ -40,15 +40,14 @@ module.exports = app => {
   }]).then(answers => searchNpm(app, answers.searchTerm));
 };
 
-const generatorMatchTerm = (generator, term) => `${generator.name} ${generator.description}`.indexOf(term) !== -1;
 const getGenerators = _.memoize(term => npmKeyword(['yeoman-generator', term]));
 
 function searchMatchingGenerators(app, term, cb) {
   function handleBlacklist(blacklist) {
     const installedGenerators = app.env.getGeneratorNames();
 
-    getGenerators(term).then(allGenerators => {
-      cb(null, allGenerators.filter(generator => {
+    getGenerators(term).then(generators => {
+      cb(null, generators.filter(generator => {
         if (blacklist.indexOf(generator.name) !== -1) {
           return false;
         }
@@ -57,7 +56,7 @@ function searchMatchingGenerators(app, term, cb) {
           return false;
         }
 
-        return generatorMatchTerm(generator, term);
+        return generator;
       }));
     }, cb);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "yo",
   "version": "2.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -10,9 +11,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -20,6 +21,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -32,12 +36,22 @@
     "aggregate-error": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-1.0.0.tgz",
-      "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w="
+      "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
+      "requires": {
+        "clean-stack": "1.3.0",
+        "indent-string": "3.2.0"
+      }
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -49,7 +63,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -65,12 +84,15 @@
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38="
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "requires": {
+        "string-width": "2.1.1"
+      }
     },
     "ansi-escapes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -91,24 +113,34 @@
     "are-we-there-yet": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0="
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
+      }
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
     },
     "arr-flatten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-      "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "array-differ": {
@@ -117,15 +149,30 @@
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
+    "array-slice": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
+      "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8=",
+      "dev": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk="
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -149,9 +196,9 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
       "version": "1.0.2",
@@ -160,9 +207,12 @@
       "dev": true
     },
     "async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
-      "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -170,9 +220,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.6.0",
@@ -180,21 +230,29 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "beeper": {
       "version": "1.1.1",
@@ -205,12 +263,21 @@
     "bin-version": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
-      "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144="
+      "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
+      "requires": {
+        "find-versions": "1.2.1"
+      }
     },
     "bin-version-check": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
       "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
+      "requires": {
+        "bin-version": "1.0.4",
+        "minimist": "1.2.0",
+        "semver": "4.3.6",
+        "semver-truncate": "1.1.2"
+      },
       "dependencies": {
         "semver": {
           "version": "4.3.6",
@@ -220,32 +287,79 @@
       }
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
     },
     "boxen": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
-      "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
+      "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
+      "requires": {
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.3.0",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "1.0.0"
+      },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
     "brace-expansion": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -268,7 +382,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -284,7 +401,11 @@
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc="
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -301,23 +422,44 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "chardet": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.0.tgz",
+      "integrity": "sha1-C74TVaxE16PtSpJXB8TvcPgZD2w="
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clean-stack": {
@@ -333,7 +475,10 @@
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU="
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
     },
     "cli-list": {
       "version": "0.2.0",
@@ -341,9 +486,9 @@
       "integrity": "sha1-fmc+4N05phGkhkduU/PGs5QctYI="
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "2.1.0",
@@ -351,6 +496,11 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -362,14 +512,18 @@
       }
     },
     "clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
     },
     "clone-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
-      "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw="
+      "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw=",
+      "requires": {
+        "is-regexp": "1.0.0",
+        "is-supported-regexp-flag": "1.0.0"
+      }
     },
     "clone-stats": {
       "version": "0.0.1",
@@ -387,24 +541,30 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
     },
     "color-name": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
-      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "concat-map": {
@@ -415,12 +575,25 @@
     "concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc="
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "configstore": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
-      "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "requires": {
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.1.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
+      }
     },
     "contains-path": {
       "version": "0.1.0",
@@ -432,12 +605,16 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
       "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buf-compare": "1.0.1",
+        "is-error": "2.2.1"
+      }
     },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
       "dev": true
     },
     "core-util-is": {
@@ -446,22 +623,105 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
-      "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
       "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      },
       "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
         "caseless": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
           "dev": true
         },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
         "har-validator": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.11.0",
+            "is-my-json-valid": "2.16.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
         },
         "qs": {
           "version": "6.3.2",
@@ -473,7 +733,38 @@
           "version": "2.79.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.1.0"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "tunnel-agent": {
           "version": "0.4.3",
@@ -486,22 +777,47 @@
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y="
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
     },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk="
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
     },
     "cross-spawn-async": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw="
+      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
+      "requires": {
+        "lru-cache": "4.1.1",
+        "which": "1.3.0"
+      }
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
+      }
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -511,53 +827,72 @@
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o="
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.35"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
+      "requires": {
+        "assert-plus": "1.0.0"
       }
     },
     "dateformat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-      "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.0"
+      }
+    },
     "deep-assign": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
       "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
     },
     "deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
@@ -588,7 +923,10 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
       "integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-assert": "0.2.1"
+      }
     },
     "default-uid": {
       "version": "1.0.0",
@@ -599,24 +937,44 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "1.0.3"
+      }
     },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.2.8"
+      },
       "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
-        },
         "globby": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
@@ -641,7 +999,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs-exists-sync": "0.1.0"
+      }
     },
     "detect-indent": {
       "version": "5.0.0",
@@ -649,26 +1010,45 @@
       "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "dev": true
     },
+    "diff": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
+    },
     "doctrine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "dot-prop": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
-      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "requires": {
+        "is-obj": "1.0.1"
+      }
     },
     "downgrade-root": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/downgrade-root/-/downgrade-root-1.2.2.tgz",
-      "integrity": "sha1-UxMZcVsOgf/MIusoR4uidkPhLGw="
+      "integrity": "sha1-UxMZcVsOgf/MIusoR4uidkPhLGw=",
+      "requires": {
+        "default-uid": "1.0.0",
+        "is-root": "1.0.0"
+      }
     },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME="
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -679,6 +1059,10 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
+      "requires": {
+        "onetime": "1.1.0",
+        "set-immediate-shim": "1.0.1"
+      },
       "dependencies": {
         "onetime": {
           "version": "1.1.0",
@@ -691,19 +1075,28 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "end-of-stream": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "dev": true,
+      "requires": {
+        "once": "1.3.3"
+      },
       "dependencies": {
         "once": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         }
       }
     },
@@ -711,48 +1104,88 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
       "integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "es5-ext": {
-      "version": "0.10.23",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true
+      "version": "0.10.35",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+      "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -763,13 +1196,26 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      }
     },
     "escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      },
       "dependencies": {
         "estraverse": {
           "version": "4.2.0",
@@ -784,6 +1230,43 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "doctrine": "2.0.0",
+        "escope": "3.6.0",
+        "espree": "3.5.2",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.1",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.6.1",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
         "ansi-escapes": {
           "version": "1.4.0",
@@ -795,7 +1278,10 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
         },
         "estraverse": {
           "version": "4.2.0",
@@ -807,25 +1293,41 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
         },
         "inquirer": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.2.0",
+            "figures": "1.7.0",
+            "lodash": "4.17.4",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "onetime": {
           "version": "1.1.0",
@@ -837,13 +1339,20 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
         },
         "run-async": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
           "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0"
+          }
         },
         "rx-lite": {
           "version": "3.1.2",
@@ -855,7 +1364,12 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -872,62 +1386,127 @@
       "dev": true
     },
     "eslint-formatter-pretty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.1.0.tgz",
-      "integrity": "sha1-q00G2gL+2ME66fDcVApDPvftb14=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz",
+      "integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
       "dev": true,
+      "requires": {
+        "ansi-escapes": "2.0.0",
+        "chalk": "2.3.0",
+        "log-symbols": "2.1.0",
+        "plur": "2.1.2",
+        "string-width": "2.1.1"
+      },
       "dependencies": {
         "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "log-symbols": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
-      "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
-      "dev": true
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
+      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "resolve": "1.5.0"
+      }
     },
     "eslint-module-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
-      "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
+      "requires": {
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
       }
     },
     "eslint-plugin-ava": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-4.2.0.tgz",
-      "integrity": "sha1-EuRmRlnB+ueJX6PzRsMTzriQfHc=",
-      "dev": true
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-4.2.2.tgz",
+      "integrity": "sha512-a4QDn9dyiFuwtQSQMDLDyklpf3/uQ7eT3+fVs0U/7cFPQF8IvhK3HpFCTd5iDGC7hljMDU9PFIUP+3Se4LV7fg==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "deep-strict-equal": "0.2.0",
+        "enhance-visitors": "1.0.0",
+        "espree": "3.5.2",
+        "espurify": "1.7.0",
+        "import-modules": "1.1.0",
+        "multimatch": "2.1.0",
+        "pkg-up": "2.0.0"
+      }
     },
     "eslint-plugin-import": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.3.0.tgz",
-      "integrity": "sha1-N8gB4K2g4pbL3yDD85OstbUq82s=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
+      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
       "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.1",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
+      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
         }
       }
     },
@@ -935,25 +1514,42 @@
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
       "integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-get-set-prop": "1.0.0",
+        "is-js-type": "2.0.0",
+        "is-obj-prop": "1.0.0",
+        "is-proto-prop": "1.0.0"
+      }
     },
     "eslint-plugin-promise": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
-      "integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz",
+      "integrity": "sha512-YQzM6TLTlApAr7Li8vWKR+K3WghjwKcYzY0d2roWap4SLK+kzuagJX/leTetIDWsFcTFnKNJXWupDCD6aZkP2Q==",
       "dev": true
     },
     "eslint-plugin-unicorn": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-2.1.1.tgz",
-      "integrity": "sha1-PpKUNmeZtxXham34kVlJW2iTDLM=",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-2.1.2.tgz",
+      "integrity": "sha1-md/+n0dzsEvDk1an/r1k3XACdLw=",
+      "dev": true,
+      "requires": {
+        "import-modules": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "lodash.kebabcase": "4.1.1",
+        "lodash.snakecase": "4.1.1",
+        "lodash.upperfirst": "4.3.1"
+      }
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.2.1",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
       "version": "2.7.3",
@@ -965,13 +1561,19 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.1"
+      }
     },
     "esquery": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      },
       "dependencies": {
         "estraverse": {
           "version": "4.2.0",
@@ -982,15 +1584,19 @@
       }
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "estraverse": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
           "dev": true
         }
       }
@@ -1011,17 +1617,33 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
+      }
     },
     "execa": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
-      "integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4="
+      "integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4=",
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      }
     },
     "execall": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
-      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M="
+      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "requires": {
+        "clone-regexp": "1.0.0"
+      }
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -1032,19 +1654,28 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "expand-tilde": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "extend": {
       "version": "3.0.1",
@@ -1052,26 +1683,48 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "external-editor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-      "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "requires": {
+        "chardet": "0.4.0",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
+      }
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fancy-log": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
       "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "time-stamp": "1.1.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1082,13 +1735,20 @@
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI="
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1096,37 +1756,28 @@
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
-    "fileset": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
-      "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
-      "dev": true,
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true
-        }
-      }
-    },
     "fill-keys": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
+      }
     },
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "filter-obj": {
       "version": "1.1.0",
@@ -1142,29 +1793,66 @@
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "find-versions": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
-      "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I="
+      "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
+      "requires": {
+        "array-uniq": "1.0.3",
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0",
+        "semver-regex": "1.0.0"
+      }
     },
     "findup-sync": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
       "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "detect-file": "0.1.0",
+        "is-glob": "2.0.1",
+        "micromatch": "2.3.11",
+        "resolve-dir": "0.1.1"
+      }
     },
     "fined": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
-      "integrity": "sha1-WyhCS3YNdZiWC374SA3/itNmDpc=",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.1"
+      },
+      "dependencies": {
+        "expand-tilde": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "1.0.1"
+          }
+        }
+      }
     },
     "first-chunk-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
-      "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA="
+      "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
     },
     "flagged-respawn": {
       "version": "0.3.2",
@@ -1173,10 +1861,16 @@
       "dev": true
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -1188,7 +1882,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "foreachasync": {
       "version": "3.0.0",
@@ -1201,15 +1898,23 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
     },
     "formatio": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.2"
+      }
     },
     "fs-exists-sync": {
       "version": "0.1.0",
@@ -1225,24 +1930,43 @@
     "fullname": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/fullname/-/fullname-3.3.0.tgz",
-      "integrity": "sha1-oIdH1pISKWELgXi3YU/OEMsYX1o="
+      "integrity": "sha1-oIdH1pISKWELgXi3YU/OEMsYX1o=",
+      "requires": {
+        "execa": "0.6.3",
+        "filter-obj": "1.1.0",
+        "mem": "1.1.0",
+        "p-any": "1.1.0",
+        "p-try": "1.0.0",
+        "passwd-user": "2.1.0",
+        "rc": "1.2.2"
+      }
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "gauge": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-      "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM="
+      "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+      "requires": {
+        "ansi": "0.3.1",
+        "has-unicode": "2.0.1",
+        "lodash.pad": "4.5.1",
+        "lodash.padend": "4.6.1",
+        "lodash.padstart": "4.6.1"
+      }
     },
     "gaze": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globule": "0.1.0"
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -1254,7 +1978,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "get-set-props": {
       "version": "0.1.0",
@@ -1276,37 +2003,67 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "glob-stream": {
       "version": "3.1.18",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
+      "requires": {
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
+      },
       "dependencies": {
         "glob": {
           "version": "4.5.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -1318,13 +2075,22 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -1336,7 +2102,11 @@
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
         }
       }
     },
@@ -1344,25 +2114,49 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gaze": "0.5.2"
+      }
     },
     "glob2base": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-index": "0.1.1"
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "requires": {
+        "ini": "1.3.4"
+      }
     },
     "global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "global-prefix": "0.1.5",
+        "is-windows": "0.2.0"
+      }
     },
     "global-prefix": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.4",
+        "is-windows": "0.2.0",
+        "which": "1.3.0"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -1370,17 +2164,46 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "requires": {
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
+      }
+    },
     "globule": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
+      "requires": {
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
+      },
       "dependencies": {
         "glob": {
           "version": "3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
+          }
         },
         "graceful-fs": {
           "version": "1.2.3",
@@ -1410,7 +2233,11 @@
           "version": "0.2.14",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
         }
       }
     },
@@ -1418,12 +2245,28 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
     },
     "got": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA="
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -1439,7 +2282,10 @@
     "grouped-queue": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
-      "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw="
+      "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "growl": {
       "version": "1.9.2",
@@ -1452,6 +2298,21 @@
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.0.4",
+        "liftoff": "2.3.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
+      },
       "dependencies": {
         "semver": {
           "version": "4.3.6",
@@ -1466,6 +2327,11 @@
       "resolved": "https://registry.npmjs.org/gulp-coveralls/-/gulp-coveralls-0.1.4.tgz",
       "integrity": "sha1-L2IKyN9i0LhrS73mTaNnzEGhkMk=",
       "dev": true,
+      "requires": {
+        "coveralls": "2.13.3",
+        "gulp-util": "3.0.8",
+        "through2": "1.1.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -1477,7 +2343,13 @@
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -1489,33 +2361,77 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.1.14",
+            "xtend": "4.0.1"
+          }
         }
       }
     },
     "gulp-istanbul": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/gulp-istanbul/-/gulp-istanbul-1.1.1.tgz",
-      "integrity": "sha1-4JTZj0K/pNmo5TZvQU7ZoJo8ZTc=",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/gulp-istanbul/-/gulp-istanbul-1.1.2.tgz",
+      "integrity": "sha512-53+BDhGlGNHYfeFh/mSXWhNu9wSFmE8qAEFj6ViMiWzTwI9pYxedUxMmGfigwaddsHHQxBl9TgnzUydrX84Kog==",
+      "dev": true,
+      "requires": {
+        "gulp-util": "3.0.8",
+        "istanbul": "0.4.5",
+        "istanbul-threshold-checker": "0.2.1",
+        "lodash": "4.17.4",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      }
     },
     "gulp-mocha": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-3.0.1.tgz",
       "integrity": "sha1-qwyiw5QDcYF03drXUOY6Yb4X4EE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-util": "3.0.8",
+        "mocha": "3.5.3",
+        "plur": "2.1.2",
+        "req-cwd": "1.0.1",
+        "temp": "0.8.3",
+        "through": "2.3.8"
+      }
     },
     "gulp-nsp": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/gulp-nsp/-/gulp-nsp-2.4.2.tgz",
       "integrity": "sha1-nqbAkbj63yeSqksL068Bzd4VDvI=",
       "dev": true,
+      "requires": {
+        "gulp-util": "3.0.7",
+        "nsp": "2.3.0"
+      },
       "dependencies": {
         "gulp-util": {
           "version": "3.0.7",
           "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
           "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
           "dev": true,
+          "requires": {
+            "array-differ": "1.0.0",
+            "array-uniq": "1.0.2",
+            "beeper": "1.1.0",
+            "chalk": "1.1.3",
+            "dateformat": "1.0.12",
+            "fancy-log": "1.2.0",
+            "gulplog": "1.0.0",
+            "has-gulplog": "0.1.0",
+            "lodash._reescape": "3.0.0",
+            "lodash._reevaluate": "3.0.0",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.template": "3.6.2",
+            "minimist": "1.2.0",
+            "multipipe": "0.1.2",
+            "object-assign": "3.0.0",
+            "replace-ext": "0.0.1",
+            "through2": "2.0.1",
+            "vinyl": "0.5.3"
+          },
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
@@ -1540,6 +2456,13 @@
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
@@ -1558,6 +2481,9 @@
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
@@ -1572,6 +2498,9 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
@@ -1594,6 +2523,10 @@
               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
               "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
               "dev": true,
+              "requires": {
+                "get-stdin": "4.0.1",
+                "meow": "3.7.0"
+              },
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
@@ -1606,12 +2539,28 @@
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                   "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
                   "dev": true,
+                  "requires": {
+                    "camelcase-keys": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "loud-rejection": "1.3.0",
+                    "map-obj": "1.0.1",
+                    "minimist": "1.2.0",
+                    "normalize-package-data": "2.3.5",
+                    "object-assign": "4.0.1",
+                    "read-pkg-up": "1.0.1",
+                    "redent": "1.0.0",
+                    "trim-newlines": "1.0.0"
+                  },
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "2.1.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                       "dev": true,
+                      "requires": {
+                        "camelcase": "2.1.1",
+                        "map-obj": "1.0.1"
+                      },
                       "dependencies": {
                         "camelcase": {
                           "version": "2.1.1",
@@ -1632,6 +2581,10 @@
                       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                       "integrity": "sha1-8omjkvF9K6rPGU0KZzAEOUQzsRU=",
                       "dev": true,
+                      "requires": {
+                        "array-find-index": "1.0.1",
+                        "signal-exit": "2.1.2"
+                      },
                       "dependencies": {
                         "array-find-index": {
                           "version": "1.0.1",
@@ -1658,6 +2611,12 @@
                       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                       "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
                       "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.4",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
+                      },
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.4",
@@ -1670,6 +2629,9 @@
                           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                           "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.1"
+                          },
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
@@ -1690,12 +2652,19 @@
                           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
                           "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
+                          },
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
                               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                               "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.2.0"
+                              },
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.0",
@@ -1710,6 +2679,10 @@
                               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                               "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                               "dev": true,
+                              "requires": {
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.2.0"
+                              },
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
@@ -1740,24 +2713,38 @@
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                       "dev": true,
+                      "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                      },
                       "dependencies": {
                         "find-up": {
                           "version": "1.1.2",
                           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                           "dev": true,
+                          "requires": {
+                            "path-exists": "2.1.0",
+                            "pinkie-promise": "2.0.0"
+                          },
                           "dependencies": {
                             "path-exists": {
                               "version": "2.1.0",
                               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                               "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                              "dev": true
+                              "dev": true,
+                              "requires": {
+                                "pinkie-promise": "2.0.0"
+                              }
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
                               "dev": true,
+                              "requires": {
+                                "pinkie": "2.0.4"
+                              },
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
@@ -1774,12 +2761,24 @@
                           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                           "dev": true,
+                          "requires": {
+                            "load-json-file": "1.1.0",
+                            "normalize-package-data": "2.3.5",
+                            "path-type": "1.1.0"
+                          },
                           "dependencies": {
                             "load-json-file": {
                               "version": "1.1.0",
                               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                               "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                               "dev": true,
+                              "requires": {
+                                "graceful-fs": "4.1.3",
+                                "parse-json": "2.2.0",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.0",
+                                "strip-bom": "2.0.0"
+                              },
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.3",
@@ -1792,12 +2791,18 @@
                                   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                                   "dev": true,
+                                  "requires": {
+                                    "error-ex": "1.3.0"
+                                  },
                                   "dependencies": {
                                     "error-ex": {
                                       "version": "1.3.0",
                                       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                       "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                                       "dev": true,
+                                      "requires": {
+                                        "is-arrayish": "0.2.1"
+                                      },
                                       "dependencies": {
                                         "is-arrayish": {
                                           "version": "0.2.1",
@@ -1820,6 +2825,9 @@
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
                                   "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
@@ -1834,6 +2842,9 @@
                                   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                                   "dev": true,
+                                  "requires": {
+                                    "is-utf8": "0.2.1"
+                                  },
                                   "dependencies": {
                                     "is-utf8": {
                                       "version": "0.2.1",
@@ -1850,6 +2861,11 @@
                               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                               "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                               "dev": true,
+                              "requires": {
+                                "graceful-fs": "4.1.3",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.0"
+                              },
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.3",
@@ -1868,6 +2884,9 @@
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
                                   "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
@@ -1888,24 +2907,37 @@
                       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
                       "dev": true,
+                      "requires": {
+                        "indent-string": "2.1.0",
+                        "strip-indent": "1.0.1"
+                      },
                       "dependencies": {
                         "indent-string": {
                           "version": "2.1.0",
                           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                           "dev": true,
+                          "requires": {
+                            "repeating": "2.0.0"
+                          },
                           "dependencies": {
                             "repeating": {
                               "version": "2.0.0",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                               "integrity": "sha1-/SfW0mTRj76/qlZVPde4JTWlA04=",
                               "dev": true,
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
                                   "dev": true,
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
@@ -1923,7 +2955,10 @@
                           "version": "1.0.1",
                           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "get-stdin": "4.0.1"
+                          }
                         }
                       }
                     },
@@ -1942,6 +2977,10 @@
               "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
               "integrity": "sha1-1aUbU+mrIsoH1VjytnrlX9tfy9g=",
               "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "time-stamp": "1.0.0"
+              },
               "dependencies": {
                 "time-stamp": {
                   "version": "1.0.0",
@@ -1956,12 +2995,18 @@
               "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
               "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
               "dev": true,
+              "requires": {
+                "glogg": "1.0.0"
+              },
               "dependencies": {
                 "glogg": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
                   "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
                   "dev": true,
+                  "requires": {
+                    "sparkles": "1.0.0"
+                  },
                   "dependencies": {
                     "sparkles": {
                       "version": "1.0.0",
@@ -1978,6 +3023,9 @@
               "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
               "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
               "dev": true,
+              "requires": {
+                "sparkles": "1.0.0"
+              },
               "dependencies": {
                 "sparkles": {
                   "version": "1.0.0",
@@ -2010,6 +3058,17 @@
               "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
               "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
               "dev": true,
+              "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
+              },
               "dependencies": {
                 "lodash._basecopy": {
                   "version": "3.0.1",
@@ -2040,6 +3099,9 @@
                   "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
                   "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
                   "dev": true,
+                  "requires": {
+                    "lodash._root": "3.0.1"
+                  },
                   "dependencies": {
                     "lodash._root": {
                       "version": "3.0.1",
@@ -2054,6 +3116,11 @@
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
                   "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1",
+                    "lodash.isarguments": "3.0.8",
+                    "lodash.isarray": "3.0.4"
+                  },
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
@@ -2085,7 +3152,11 @@
                   "version": "3.1.1",
                   "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
                   "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "lodash._reinterpolate": "3.0.0",
+                    "lodash.escape": "3.2.0"
+                  }
                 }
               }
             },
@@ -2100,18 +3171,30 @@
               "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
               "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
               "dev": true,
+              "requires": {
+                "duplexer2": "0.0.2"
+              },
               "dependencies": {
                 "duplexer2": {
                   "version": "0.0.2",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
                   "dev": true,
+                  "requires": {
+                    "readable-stream": "1.1.13"
+                  },
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
                       "dev": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -2160,12 +3243,24 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
               "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
               "dev": true,
+              "requires": {
+                "readable-stream": "2.0.6",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                   "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.6",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -2218,6 +3313,11 @@
               "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
               "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
               "dev": true,
+              "requires": {
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
+              },
               "dependencies": {
                 "clone": {
                   "version": "1.0.2",
@@ -2240,12 +3340,31 @@
           "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.3.0.tgz",
           "integrity": "sha1-pC+hULgtB00RgSwW2AVHLVHbz6g=",
           "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "cli-table": "0.3.1",
+            "https-proxy-agent": "1.0.0",
+            "joi": "6.10.1",
+            "nodesecurity-npm-utils": "4.0.1",
+            "path-is-absolute": "1.0.0",
+            "rc": "1.1.6",
+            "semver": "5.1.0",
+            "subcommand": "2.0.3",
+            "wreck": "6.3.0"
+          },
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
@@ -2264,6 +3383,9 @@
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
@@ -2278,6 +3400,9 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
@@ -2300,6 +3425,9 @@
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
               "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
               "dev": true,
+              "requires": {
+                "colors": "1.0.3"
+              },
               "dependencies": {
                 "colors": {
                   "version": "1.0.3",
@@ -2314,12 +3442,21 @@
               "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
               "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
               "dev": true,
+              "requires": {
+                "agent-base": "2.0.1",
+                "debug": "2.2.0",
+                "extend": "3.0.0"
+              },
               "dependencies": {
                 "agent-base": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
                   "integrity": "sha1-vY+ehqjrIh//oHvRS+/VXfFCgV4=",
                   "dev": true,
+                  "requires": {
+                    "extend": "3.0.0",
+                    "semver": "5.0.3"
+                  },
                   "dependencies": {
                     "semver": {
                       "version": "5.0.3",
@@ -2334,6 +3471,9 @@
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
                   "dev": true,
+                  "requires": {
+                    "ms": "0.7.1"
+                  },
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
@@ -2356,6 +3496,12 @@
               "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
               "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
               "dev": true,
+              "requires": {
+                "hoek": "2.16.3",
+                "isemail": "1.2.0",
+                "moment": "2.12.0",
+                "topo": "1.1.0"
+              },
               "dependencies": {
                 "hoek": {
                   "version": "2.16.3",
@@ -2379,7 +3525,10 @@
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
                   "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
                 }
               }
             },
@@ -2388,18 +3537,41 @@
               "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-4.0.1.tgz",
               "integrity": "sha1-mdXi9waZx2humo7Rw6KZK2d19Gc=",
               "dev": true,
+              "requires": {
+                "semver": "5.1.0",
+                "silent-npm-registry-client": "2.0.0"
+              },
               "dependencies": {
                 "silent-npm-registry-client": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-2.0.0.tgz",
                   "integrity": "sha1-TYh16tZIp5EWlg6PhPfsNsDxvRA=",
                   "dev": true,
+                  "requires": {
+                    "npm-registry-client": "7.1.0",
+                    "xtend": "4.0.1"
+                  },
                   "dependencies": {
                     "npm-registry-client": {
                       "version": "7.1.0",
                       "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.1.0.tgz",
                       "integrity": "sha1-474Uqyef5RI+FatcimUERUFWZKU=",
                       "dev": true,
+                      "requires": {
+                        "chownr": "1.0.1",
+                        "concat-stream": "1.5.1",
+                        "graceful-fs": "4.1.3",
+                        "mkdirp": "0.5.1",
+                        "normalize-package-data": "2.3.5",
+                        "npm-package-arg": "4.1.0",
+                        "npmlog": "2.0.3",
+                        "once": "1.3.3",
+                        "request": "2.69.0",
+                        "retry": "0.8.0",
+                        "rimraf": "2.5.2",
+                        "semver": "5.1.0",
+                        "slide": "1.1.6"
+                      },
                       "dependencies": {
                         "chownr": {
                           "version": "1.0.1",
@@ -2412,6 +3584,11 @@
                           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
                           "integrity": "sha1-87gKz54fSOOHXAaItBtsMWAu6hw=",
                           "dev": true,
+                          "requires": {
+                            "inherits": "2.0.1",
+                            "readable-stream": "2.0.6",
+                            "typedarray": "0.0.6"
+                          },
                           "dependencies": {
                             "inherits": {
                               "version": "2.0.1",
@@ -2424,6 +3601,14 @@
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                               "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                               "dev": true,
+                              "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.1",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "1.0.6",
+                                "string_decoder": "0.10.31",
+                                "util-deprecate": "1.0.2"
+                              },
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
@@ -2476,6 +3661,9 @@
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                           "dev": true,
+                          "requires": {
+                            "minimist": "0.0.8"
+                          },
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.8",
@@ -2490,6 +3678,12 @@
                           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                           "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
                           "dev": true,
+                          "requires": {
+                            "hosted-git-info": "2.1.4",
+                            "is-builtin-module": "1.0.0",
+                            "semver": "5.1.0",
+                            "validate-npm-package-license": "3.0.1"
+                          },
                           "dependencies": {
                             "hosted-git-info": {
                               "version": "2.1.4",
@@ -2502,6 +3696,9 @@
                               "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                               "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                               "dev": true,
+                              "requires": {
+                                "builtin-modules": "1.1.1"
+                              },
                               "dependencies": {
                                 "builtin-modules": {
                                   "version": "1.1.1",
@@ -2516,12 +3713,19 @@
                               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                               "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
                               "dev": true,
+                              "requires": {
+                                "spdx-correct": "1.0.2",
+                                "spdx-expression-parse": "1.0.2"
+                              },
                               "dependencies": {
                                 "spdx-correct": {
                                   "version": "1.0.2",
                                   "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                   "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                                   "dev": true,
+                                  "requires": {
+                                    "spdx-license-ids": "1.2.0"
+                                  },
                                   "dependencies": {
                                     "spdx-license-ids": {
                                       "version": "1.2.0",
@@ -2536,6 +3740,10 @@
                                   "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                                   "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                                   "dev": true,
+                                  "requires": {
+                                    "spdx-exceptions": "1.0.4",
+                                    "spdx-license-ids": "1.2.0"
+                                  },
                                   "dependencies": {
                                     "spdx-exceptions": {
                                       "version": "1.0.4",
@@ -2560,6 +3768,10 @@
                           "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
                           "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
                           "dev": true,
+                          "requires": {
+                            "hosted-git-info": "2.1.4",
+                            "semver": "5.1.0"
+                          },
                           "dependencies": {
                             "hosted-git-info": {
                               "version": "2.1.4",
@@ -2575,6 +3787,11 @@
                           "integrity": "sha1-Ag+ZNR8MAuOZxnS6JW58TTs90pg=",
                           "dev": true,
                           "optional": true,
+                          "requires": {
+                            "ansi": "0.3.1",
+                            "are-we-there-yet": "1.1.2",
+                            "gauge": "1.2.7"
+                          },
                           "dependencies": {
                             "ansi": {
                               "version": "0.3.1",
@@ -2588,6 +3805,10 @@
                               "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
                               "dev": true,
                               "optional": true,
+                              "requires": {
+                                "delegates": "1.0.0",
+                                "readable-stream": "2.0.6"
+                              },
                               "dependencies": {
                                 "delegates": {
                                   "version": "1.0.0",
@@ -2602,6 +3823,14 @@
                                   "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                                   "dev": true,
                                   "optional": true,
+                                  "requires": {
+                                    "core-util-is": "1.0.2",
+                                    "inherits": "2.0.1",
+                                    "isarray": "1.0.0",
+                                    "process-nextick-args": "1.0.6",
+                                    "string_decoder": "0.10.31",
+                                    "util-deprecate": "1.0.2"
+                                  },
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.2",
@@ -2655,6 +3884,13 @@
                               "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
                               "dev": true,
                               "optional": true,
+                              "requires": {
+                                "ansi": "0.3.1",
+                                "has-unicode": "2.0.0",
+                                "lodash.pad": "4.1.0",
+                                "lodash.padend": "4.2.0",
+                                "lodash.padstart": "4.2.0"
+                              },
                               "dependencies": {
                                 "has-unicode": {
                                   "version": "2.0.0",
@@ -2669,13 +3905,20 @@
                                   "integrity": "sha1-2746loH8y2mXBHOiJj9QwZasOqk=",
                                   "dev": true,
                                   "optional": true,
+                                  "requires": {
+                                    "lodash.repeat": "4.0.0",
+                                    "lodash.tostring": "4.1.2"
+                                  },
                                   "dependencies": {
                                     "lodash.repeat": {
                                       "version": "4.0.0",
                                       "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz",
                                       "integrity": "sha1-qvVwsqsL+w3abW6TKR1UswsffSI=",
                                       "dev": true,
-                                      "optional": true
+                                      "optional": true,
+                                      "requires": {
+                                        "lodash.tostring": "4.1.2"
+                                      }
                                     },
                                     "lodash.tostring": {
                                       "version": "4.1.2",
@@ -2691,13 +3934,20 @@
                                   "integrity": "sha1-uE6MNAHUU4BVxuMhpR467hmIGhg=",
                                   "dev": true,
                                   "optional": true,
+                                  "requires": {
+                                    "lodash.repeat": "4.0.0",
+                                    "lodash.tostring": "4.1.2"
+                                  },
                                   "dependencies": {
                                     "lodash.repeat": {
                                       "version": "4.0.0",
                                       "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz",
                                       "integrity": "sha1-qvVwsqsL+w3abW6TKR1UswsffSI=",
                                       "dev": true,
-                                      "optional": true
+                                      "optional": true,
+                                      "requires": {
+                                        "lodash.tostring": "4.1.2"
+                                      }
                                     },
                                     "lodash.tostring": {
                                       "version": "4.1.2",
@@ -2713,13 +3963,20 @@
                                   "integrity": "sha1-42+J/Ww7UHIhkIdpW3Zd6D7JaYU=",
                                   "dev": true,
                                   "optional": true,
+                                  "requires": {
+                                    "lodash.repeat": "4.0.0",
+                                    "lodash.tostring": "4.1.2"
+                                  },
                                   "dependencies": {
                                     "lodash.repeat": {
                                       "version": "4.0.0",
                                       "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz",
                                       "integrity": "sha1-qvVwsqsL+w3abW6TKR1UswsffSI=",
                                       "dev": true,
-                                      "optional": true
+                                      "optional": true,
+                                      "requires": {
+                                        "lodash.tostring": "4.1.2"
+                                      }
                                     },
                                     "lodash.tostring": {
                                       "version": "4.1.2",
@@ -2738,6 +3995,9 @@
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                           "dev": true,
+                          "requires": {
+                            "wrappy": "1.0.1"
+                          },
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
@@ -2752,6 +4012,29 @@
                           "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
                           "integrity": "sha1-z5HS4AB1KxIXFVwAUkGRGZGiNGo=",
                           "dev": true,
+                          "requires": {
+                            "aws-sign2": "0.6.0",
+                            "aws4": "1.3.2",
+                            "bl": "1.0.3",
+                            "caseless": "0.11.0",
+                            "combined-stream": "1.0.5",
+                            "extend": "3.0.0",
+                            "forever-agent": "0.6.1",
+                            "form-data": "1.0.0-rc4",
+                            "har-validator": "2.0.6",
+                            "hawk": "3.1.3",
+                            "http-signature": "1.1.1",
+                            "is-typedarray": "1.0.0",
+                            "isstream": "0.1.2",
+                            "json-stringify-safe": "5.0.1",
+                            "mime-types": "2.1.10",
+                            "node-uuid": "1.4.7",
+                            "oauth-sign": "0.8.1",
+                            "qs": "6.0.2",
+                            "stringstream": "0.0.5",
+                            "tough-cookie": "2.2.2",
+                            "tunnel-agent": "0.4.2"
+                          },
                           "dependencies": {
                             "aws-sign2": {
                               "version": "0.6.0",
@@ -2764,12 +4047,19 @@
                               "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
                               "integrity": "sha1-054L7kEs7Q6O2Uoj4xTzE6lbn9E=",
                               "dev": true,
+                              "requires": {
+                                "lru-cache": "4.0.1"
+                              },
                               "dependencies": {
                                 "lru-cache": {
                                   "version": "4.0.1",
                                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
                                   "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
                                   "dev": true,
+                                  "requires": {
+                                    "pseudomap": "1.0.2",
+                                    "yallist": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "pseudomap": {
                                       "version": "1.0.2",
@@ -2792,12 +4082,23 @@
                               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
                               "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
                               "dev": true,
+                              "requires": {
+                                "readable-stream": "2.0.6"
+                              },
                               "dependencies": {
                                 "readable-stream": {
                                   "version": "2.0.6",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                                   "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                                   "dev": true,
+                                  "requires": {
+                                    "core-util-is": "1.0.2",
+                                    "inherits": "2.0.1",
+                                    "isarray": "1.0.0",
+                                    "process-nextick-args": "1.0.6",
+                                    "string_decoder": "0.10.31",
+                                    "util-deprecate": "1.0.2"
+                                  },
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.2",
@@ -2850,6 +4151,9 @@
                               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                               "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                               "dev": true,
+                              "requires": {
+                                "delayed-stream": "1.0.0"
+                              },
                               "dependencies": {
                                 "delayed-stream": {
                                   "version": "1.0.0",
@@ -2876,6 +4180,11 @@
                               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
                               "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
                               "dev": true,
+                              "requires": {
+                                "async": "1.5.2",
+                                "combined-stream": "1.0.5",
+                                "mime-types": "2.1.10"
+                              },
                               "dependencies": {
                                 "async": {
                                   "version": "1.5.2",
@@ -2890,12 +4199,21 @@
                               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                               "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
                               "dev": true,
+                              "requires": {
+                                "chalk": "1.1.3",
+                                "commander": "2.9.0",
+                                "is-my-json-valid": "2.13.1",
+                                "pinkie-promise": "2.0.0"
+                              },
                               "dependencies": {
                                 "commander": {
                                   "version": "2.9.0",
                                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                                   "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                                   "dev": true,
+                                  "requires": {
+                                    "graceful-readlink": "1.0.1"
+                                  },
                                   "dependencies": {
                                     "graceful-readlink": {
                                       "version": "1.0.1",
@@ -2910,6 +4228,12 @@
                                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                                   "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
                                   "dev": true,
+                                  "requires": {
+                                    "generate-function": "2.0.0",
+                                    "generate-object-property": "1.2.0",
+                                    "jsonpointer": "2.0.0",
+                                    "xtend": "4.0.1"
+                                  },
                                   "dependencies": {
                                     "generate-function": {
                                       "version": "2.0.0",
@@ -2922,6 +4246,9 @@
                                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                                       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                                       "dev": true,
+                                      "requires": {
+                                        "is-property": "1.0.2"
+                                      },
                                       "dependencies": {
                                         "is-property": {
                                           "version": "1.0.2",
@@ -2944,6 +4271,9 @@
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
                                   "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
@@ -2960,18 +4290,30 @@
                               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                               "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                               "dev": true,
+                              "requires": {
+                                "boom": "2.10.1",
+                                "cryptiles": "2.0.5",
+                                "hoek": "2.16.3",
+                                "sntp": "1.0.9"
+                              },
                               "dependencies": {
                                 "boom": {
                                   "version": "2.10.1",
                                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                                   "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                                  "dev": true
+                                  "dev": true,
+                                  "requires": {
+                                    "hoek": "2.16.3"
+                                  }
                                 },
                                 "cryptiles": {
                                   "version": "2.0.5",
                                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                                   "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                                  "dev": true
+                                  "dev": true,
+                                  "requires": {
+                                    "boom": "2.10.1"
+                                  }
                                 },
                                 "hoek": {
                                   "version": "2.16.3",
@@ -2983,7 +4325,10 @@
                                   "version": "1.0.9",
                                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                                   "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                                  "dev": true
+                                  "dev": true,
+                                  "requires": {
+                                    "hoek": "2.16.3"
+                                  }
                                 }
                               }
                             },
@@ -2992,6 +4337,11 @@
                               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                               "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                               "dev": true,
+                              "requires": {
+                                "assert-plus": "0.2.0",
+                                "jsprim": "1.2.2",
+                                "sshpk": "1.7.4"
+                              },
                               "dependencies": {
                                 "assert-plus": {
                                   "version": "0.2.0",
@@ -3004,6 +4354,11 @@
                                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                                   "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE=",
                                   "dev": true,
+                                  "requires": {
+                                    "extsprintf": "1.0.2",
+                                    "json-schema": "0.2.2",
+                                    "verror": "1.3.6"
+                                  },
                                   "dependencies": {
                                     "extsprintf": {
                                       "version": "1.0.2",
@@ -3021,7 +4376,10 @@
                                       "version": "1.3.6",
                                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                                       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                                      "dev": true
+                                      "dev": true,
+                                      "requires": {
+                                        "extsprintf": "1.0.2"
+                                      }
                                     }
                                   }
                                 },
@@ -3030,6 +4388,15 @@
                                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
                                   "integrity": "sha1-rXtH3vymHIQV2WQkO2KwzmD7yjg=",
                                   "dev": true,
+                                  "requires": {
+                                    "asn1": "0.2.3",
+                                    "assert-plus": "0.2.0",
+                                    "dashdash": "1.13.0",
+                                    "ecc-jsbn": "0.1.1",
+                                    "jodid25519": "1.0.2",
+                                    "jsbn": "0.1.0",
+                                    "tweetnacl": "0.14.3"
+                                  },
                                   "dependencies": {
                                     "asn1": {
                                       "version": "0.2.3",
@@ -3042,6 +4409,9 @@
                                       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
                                       "integrity": "sha1-parm/Z2OFWYk6w3ZJZ6xK6JFOFo=",
                                       "dev": true,
+                                      "requires": {
+                                        "assert-plus": "1.0.0"
+                                      },
                                       "dependencies": {
                                         "assert-plus": {
                                           "version": "1.0.0",
@@ -3056,14 +4426,20 @@
                                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                                       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                                       "dev": true,
-                                      "optional": true
+                                      "optional": true,
+                                      "requires": {
+                                        "jsbn": "0.1.0"
+                                      }
                                     },
                                     "jodid25519": {
                                       "version": "1.0.2",
                                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                                       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                                       "dev": true,
-                                      "optional": true
+                                      "optional": true,
+                                      "requires": {
+                                        "jsbn": "0.1.0"
+                                      }
                                     },
                                     "jsbn": {
                                       "version": "0.1.0",
@@ -3106,6 +4482,9 @@
                               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                               "integrity": "sha1-uTx8tDYuFtQQcqflRTj7TUMHCDc=",
                               "dev": true,
+                              "requires": {
+                                "mime-db": "1.22.0"
+                              },
                               "dependencies": {
                                 "mime-db": {
                                   "version": "1.22.0",
@@ -3164,18 +4543,32 @@
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                           "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
                           "dev": true,
+                          "requires": {
+                            "glob": "7.0.3"
+                          },
                           "dependencies": {
                             "glob": {
                               "version": "7.0.3",
                               "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                               "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
                               "dev": true,
+                              "requires": {
+                                "inflight": "1.0.4",
+                                "inherits": "2.0.1",
+                                "minimatch": "3.0.0",
+                                "once": "1.3.3",
+                                "path-is-absolute": "1.0.0"
+                              },
                               "dependencies": {
                                 "inflight": {
                                   "version": "1.0.4",
                                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                                   "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
                                   "dev": true,
+                                  "requires": {
+                                    "once": "1.3.3",
+                                    "wrappy": "1.0.1"
+                                  },
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.1",
@@ -3196,12 +4589,19 @@
                                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                                   "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
                                   "dev": true,
+                                  "requires": {
+                                    "brace-expansion": "1.1.3"
+                                  },
                                   "dependencies": {
                                     "brace-expansion": {
                                       "version": "1.1.3",
                                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                       "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
                                       "dev": true,
+                                      "requires": {
+                                        "balanced-match": "0.3.0",
+                                        "concat-map": "0.0.1"
+                                      },
                                       "dependencies": {
                                         "balanced-match": {
                                           "version": "0.3.0",
@@ -3252,6 +4652,12 @@
               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
               "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
               "dev": true,
+              "requires": {
+                "deep-extend": "0.4.1",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "1.0.4"
+              },
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.1",
@@ -3290,6 +4696,12 @@
               "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
               "integrity": "sha1-mz/Rp1PjxEHwBBDLRBMdhlX1LDI=",
               "dev": true,
+              "requires": {
+                "cliclopts": "1.1.1",
+                "debug": "2.2.0",
+                "minimist": "1.2.0",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "cliclopts": {
                   "version": "1.1.1",
@@ -3302,6 +4714,9 @@
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
                   "dev": true,
+                  "requires": {
+                    "ms": "0.7.1"
+                  },
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
@@ -3330,12 +4745,19 @@
               "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
               "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
               "dev": true,
+              "requires": {
+                "boom": "2.10.1",
+                "hoek": "2.16.3"
+              },
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
                 },
                 "hoek": {
                   "version": "2.16.3",
@@ -3353,13 +4775,37 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
       "integrity": "sha1-8SF2wtBCL2AwbCQv/2oBo5T6ugk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-util": "3.0.8",
+        "through2": "2.0.3"
+      }
     },
     "gulp-util": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.0",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
+      },
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
@@ -3371,7 +4817,12 @@
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
         }
       }
     },
@@ -3379,13 +4830,22 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glogg": "1.0.0"
+      }
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -3397,41 +4857,70 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
     "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.3.0",
+        "har-schema": "2.0.0"
+      }
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "has-gulplog": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
+      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "1.4.1"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -3439,45 +4928,68 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
     },
     "hosted-git-info": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
     },
     "humanize-string": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/humanize-string/-/humanize-string-1.0.1.tgz",
-      "integrity": "sha1-/OLWxUXvwl3qHyMjUYLJjaAYC0I="
+      "integrity": "sha1-/OLWxUXvwl3qHyMjUYLJjaAYC0I=",
+      "requires": {
+        "decamelize": "1.2.0"
+      }
     },
     "iconv-lite": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
-      "integrity": "sha1-T9qjs4rLwsAxsEXQ7c3+HsqxjI0="
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "import-lazy": {
@@ -3485,20 +4997,30 @@
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
+    "import-modules": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/import-modules/-/import-modules-1.1.0.tgz",
+      "integrity": "sha1-dI23nFzEK7lwHvq0JPiU5yYA6dw=",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.1.0.tgz",
-      "integrity": "sha1-CP9DNGAziDmbMp5rlTjcejz13n0="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -3511,14 +5033,83 @@
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
     },
     "inquirer": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.1.0.tgz",
-      "integrity": "sha512-JLl89yPOEoGohLjeGs3XCekeovADbrEw/WRJQYgPED6zeJWrpIsY9i9/rn+VltZox/9w94lVYqo94QfEmniB1w=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.1.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "insight": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/insight/-/insight-0.8.4.tgz",
       "integrity": "sha1-ZxyvZbR8n+jD0bMgbPRbshG3WIQ=",
+      "requires": {
+        "async": "1.5.2",
+        "chalk": "1.1.3",
+        "configstore": "1.4.0",
+        "inquirer": "0.10.1",
+        "lodash.debounce": "3.1.1",
+        "object-assign": "4.1.1",
+        "os-name": "1.0.3",
+        "request": "2.83.0",
+        "tough-cookie": "2.3.3",
+        "uuid": "3.1.0"
+      },
       "dependencies": {
         "ansi-escapes": {
           "version": "1.4.0",
@@ -3533,7 +5124,10 @@
         "cli-cursor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc="
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
         },
         "cli-width": {
           "version": "1.1.1",
@@ -3544,6 +5138,16 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
           "integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "os-tmpdir": "1.0.2",
+            "osenv": "0.1.4",
+            "uuid": "2.0.3",
+            "write-file-atomic": "1.3.4",
+            "xdg-basedir": "2.0.0"
+          },
           "dependencies": {
             "uuid": {
               "version": "2.0.3",
@@ -3555,12 +5159,30 @@
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4="
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
         },
         "inquirer": {
           "version": "0.10.1",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.10.1.tgz",
-          "integrity": "sha1-6iXkzmnKFF4FyZ5G3P7AXkASWUo="
+          "integrity": "sha1-6iXkzmnKFF4FyZ5G3P7AXkASWUo=",
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "3.10.1",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
         },
         "lodash": {
           "version": "3.10.1",
@@ -3575,12 +5197,19 @@
         "restore-cursor": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE="
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
         },
         "run-async": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k="
+          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+          "requires": {
+            "once": "1.4.0"
+          }
         },
         "rx-lite": {
           "version": "3.1.2",
@@ -3590,32 +5219,44 @@
         "write-file-atomic": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8="
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
         },
         "xdg-basedir": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-          "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I="
+          "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+          "requires": {
+            "os-homedir": "1.0.2"
+          }
         }
       }
     },
     "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
       "dev": true
     },
     "irregular-plurals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz",
-      "integrity": "sha1-OPKZg0uowAwwvpxVThNyaXUv86w=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
       "dev": true
     },
     "is-absolute": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-relative": "0.2.1",
+        "is-windows": "0.2.0"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -3623,15 +5264,18 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-docker": {
       "version": "1.1.0",
@@ -3648,7 +5292,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-error": {
       "version": "2.2.1",
@@ -3671,7 +5318,10 @@
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -3682,25 +5332,50 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
       "integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-set-props": "0.1.0",
+        "lowercase-keys": "1.0.0"
+      }
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "requires": {
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-js-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
       "integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-types": "1.0.0"
+      }
     },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-npm": {
       "version": "1.0.0",
@@ -3711,7 +5386,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-obj": {
       "version": "1.0.1",
@@ -3722,13 +5400,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
       "integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "1.0.0",
+        "obj-props": "1.1.0"
+      }
     },
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -3740,19 +5421,40 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -3781,7 +5483,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-proto-prop/-/is-proto-prop-1.0.0.tgz",
       "integrity": "sha1-s5UflcCJkk+11PzaZUKrPoPisiA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "1.0.0",
+        "proto-props": "0.2.1"
+      }
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -3797,13 +5503,19 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-unc-path": "0.1.2"
+      }
     },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -3818,7 +5530,10 @@
     "is-scoped": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
-      "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA="
+      "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
+      "requires": {
+        "scoped-regex": "1.0.0"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -3839,7 +5554,10 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -3866,7 +5584,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -3878,6 +5599,22 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.11",
+        "js-yaml": "3.6.1",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.3.0",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -3889,6 +5626,19 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "resolve": {
@@ -3901,104 +5651,36 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
     "istanbul-threshold-checker": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-threshold-checker/-/istanbul-threshold-checker-0.1.0.tgz",
-      "integrity": "sha1-DhRCwBfLJ6hfeBc0/v0hJkBco5w=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-threshold-checker/-/istanbul-threshold-checker-0.2.1.tgz",
+      "integrity": "sha1-xdyU6PLMXNP/0zVFL4S1U8QkgzE=",
       "dev": true,
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "escodegen": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
-          "integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
-          "dev": true,
-          "dependencies": {
-            "esprima": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-              "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
-              "dev": true
-            }
-          }
-        },
-        "esprima": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
-          "integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
-          "dev": true
-        },
-        "fast-levenshtein": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-          "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
-          "dev": true
-        },
-        "istanbul": {
-          "version": "0.3.22",
-          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
-          "integrity": "sha1-PhZNhQIf4ZyYXR8OfvDD4i0BLrY=",
-          "dev": true
-        },
-        "levn": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-          "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz",
-          "integrity": "sha1-Umao9J3Zib5Pn2gbbyoMVShdDZo=",
-          "dev": true
-        },
-        "optionator": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-          "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
-          "dev": true,
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-              "dev": true
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
-        }
+      "requires": {
+        "istanbul": "0.4.5",
+        "lodash": "4.17.4"
       }
     },
-    "jodid25519": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "optional": true
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
+      }
     },
     "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-types": {
@@ -4011,7 +5693,11 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -4019,20 +5705,24 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
-    "jschardet": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.4.2.tgz",
-      "integrity": "sha1-KqEH8UKvQSHRRWWdRPUIMJYeaZo="
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -4048,7 +5738,8 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -4057,32 +5748,43 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
     },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "requires": {
+        "package-json": "4.0.1"
+      },
       "dependencies": {
         "package-json": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0="
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+          "requires": {
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.1",
+            "registry-url": "3.1.0",
+            "semver": "5.4.1"
+          }
         }
       }
     },
@@ -4103,23 +5805,56 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "liftoff": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
       "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1",
+        "findup-sync": "0.4.3",
+        "fined": "1.1.0",
+        "flagged-respawn": "0.3.2",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.mapvalues": "4.6.0",
+        "rechoir": "0.6.2",
+        "resolve": "1.5.0"
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA="
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
+      }
     },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
@@ -4137,7 +5872,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -4198,12 +5937,6 @@
       "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true
     },
-    "lodash.assignwith": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
-      "integrity": "sha1-EnqX8CrcQXUalU0ksN4X4QDgOOs=",
-      "dev": true
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -4220,18 +5953,29 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.debounce": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
-      "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU="
+      "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
+      "requires": {
+        "lodash._getnative": "3.9.1"
+      }
     },
     "lodash.escape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -4243,12 +5987,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
       "dev": true
     },
     "lodash.isequal": {
@@ -4279,7 +6017,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
@@ -4302,12 +6045,6 @@
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
     },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "dev": true
-    },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
@@ -4324,13 +6061,28 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
+      }
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
+      }
     },
     "lodash.upperfirst": {
       "version": "4.3.1",
@@ -4347,7 +6099,10 @@
     "log-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg="
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "requires": {
+        "chalk": "1.1.3"
+      }
     },
     "lolex": {
       "version": "1.3.2",
@@ -4364,7 +6119,11 @@
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8="
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "lowercase-keys": {
       "version": "1.0.0",
@@ -4372,14 +6131,21 @@
       "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
     },
     "lru-cache": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.0.tgz",
-      "integrity": "sha512-aHGs865JXz6bkB4AHL+3AhyvTFKL3iZamKVWjIUKnXOXyasJvqPK8WAjOnAQKQZVpeXDVz19u1DD0r/12bWAdQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "make-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
-      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "requires": {
+        "pify": "3.0.0"
+      }
     },
     "map-cache": {
       "version": "0.2.2",
@@ -4395,22 +6161,46 @@
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y="
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "mem-fs": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
-      "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw="
+      "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
+      "requires": {
+        "through2": "2.0.3",
+        "vinyl": "1.2.0",
+        "vinyl-file": "2.0.0"
+      }
     },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
       "dependencies": {
         "read-pkg-up": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
         }
       }
     },
@@ -4424,27 +6214,53 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      }
     },
     "mime-db": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
     },
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -4455,6 +6271,9 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -4464,16 +6283,42 @@
       }
     },
     "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
         "debug": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "diff": {
           "version": "3.2.0",
@@ -4485,26 +6330,37 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "supports-color": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
     "mockery": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.0.0.tgz",
-      "integrity": "sha1-BWmhGhhIRh/cNHz4zKLfLzEpvAM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
       "dev": true
     },
     "module-not-found-error": {
@@ -4522,19 +6378,31 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
+      }
     },
     "multipipe": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
       "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2"
+      },
       "dependencies": {
         "duplexer2": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.1.14"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -4546,7 +6414,13 @@
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -4574,10 +6448,21 @@
       "dev": true
     },
     "nock": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.13.tgz",
-      "integrity": "sha1-0Lw570PTF5mB4isujqBp+RbFeBo=",
-      "dev": true
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.0.tgz",
+      "integrity": "sha512-u9QOLOZP0DlcKzmAzCuX5PRsIhbiRJupR7hJn1cCCT7VW3ZKUrEH/oxGEtVA8Xbu4EmzH9d/VK0x/3FxCGRrRg==",
+      "dev": true,
+      "requires": {
+        "chai": "3.5.0",
+        "debug": "2.6.9",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "propagate": "0.4.0",
+        "qs": "6.5.1",
+        "semver": "5.4.1"
+      }
     },
     "node-status-codes": {
       "version": "1.0.0",
@@ -4588,109 +6473,150 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
     },
     "normalize-package-data": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
     },
     "npm-keyword": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-4.2.0.tgz",
-      "integrity": "sha1-mP/r/bsTNvJ+9f4brKDcrNCs9sA=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-5.0.0.tgz",
+      "integrity": "sha1-mbha7Cn8s4jS3TUfABO/Umh4fmc=",
+      "requires": {
+        "got": "7.1.0",
+        "registry-url": "3.1.0"
+      },
       "dependencies": {
         "got": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-          "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU="
-        },
-        "timed-out": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-          "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
-        },
-        "unzip-response": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+          "requires": {
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-plain-obj": "1.1.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.0",
+            "p-cancelable": "0.3.0",
+            "p-timeout": "1.2.1",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "1.0.0",
+            "url-to-options": "1.0.1"
+          }
         }
       }
     },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8="
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "2.0.1"
+      }
     },
     "npmlog": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-      "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI="
+      "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
+      "requires": {
+        "ansi": "0.3.1",
+        "are-we-there-yet": "1.1.4",
+        "gauge": "1.2.7"
+      }
     },
     "nsp": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.6.3.tgz",
-      "integrity": "sha1-2wUDWVPNoqs6Vx7oL6uE9MsIHRc=",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.8.1.tgz",
+      "integrity": "sha512-jvjDg2Gsw4coD/iZ5eQddsDlkvnwMCNnpG05BproSnuG+Gr1bSQMwWMcQeYje+qdDl3XznmhblMPLpZLecTORQ==",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-table": "0.3.1",
+        "cvss": "1.0.2",
+        "https-proxy-agent": "1.0.0",
+        "joi": "6.10.1",
+        "nodesecurity-npm-utils": "5.0.0",
+        "path-is-absolute": "1.0.1",
+        "rc": "1.2.1",
+        "semver": "5.4.1",
+        "subcommand": "2.1.0",
+        "wreck": "6.3.0"
+      },
       "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.0.3",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+              "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+              "dev": true
+            }
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-              "dev": true
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-              "dev": true,
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                  "dev": true
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                  "dev": true
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "cli-table": {
@@ -4698,19 +6624,68 @@
           "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
           "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
           "dev": true,
-          "dependencies": {
-            "colors": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-              "dev": true
-            }
+          "requires": {
+            "colors": "1.0.3"
           }
         },
+        "cliclopts": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
+          "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8=",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
         "cvss": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/cvss/-/cvss-1.0.1.tgz",
-          "integrity": "sha1-XAffU2FqxW1m6PR0vtJePBRhk9s=",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cvss/-/cvss-1.0.2.tgz",
+          "integrity": "sha1-32fpK/EqeW9J6Sh5nI2zunS5/NY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "dev": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         },
         "https-proxy-agent": {
@@ -4718,74 +6693,53 @@
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
-          "dependencies": {
-            "agent-base": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
-              "integrity": "sha1-vY+ehqjrIh//oHvRS+/VXfFCgV4=",
-              "dev": true,
-              "dependencies": {
-                "semver": {
-                  "version": "5.0.3",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-                  "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-                  "dev": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "dev": true,
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-                  "dev": true
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-              "dev": true
-            }
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
           }
+        },
+        "ini": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "dev": true
+        },
+        "isemail": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+          "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
+          "dev": true
         },
         "joi": {
           "version": "6.10.1",
           "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
           "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
           "dev": true,
-          "dependencies": {
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-              "dev": true
-            },
-            "isemail": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-              "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
-              "dev": true
-            },
-            "moment": {
-              "version": "2.12.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
-              "integrity": "sha1-3CVg0Zg41sBzGxpq+gRnUmTTYNY=",
-              "dev": true
-            },
-            "topo": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-              "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-              "dev": true
-            }
+          "requires": {
+            "hoek": "2.16.3",
+            "isemail": "1.2.0",
+            "moment": "2.18.1",
+            "topo": "1.1.0"
           }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "moment": {
+          "version": "2.18.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "nodesecurity-npm-utils": {
           "version": "5.0.0",
@@ -4794,87 +6748,69 @@
           "dev": true
         },
         "path-is-absolute": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "rc": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
-          "dependencies": {
-            "deep-extend": {
-              "version": "0.4.1",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-              "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-              "dev": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-              "dev": true
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-              "dev": true
-            }
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           }
         },
         "semver": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "subcommand": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
-          "integrity": "sha1-mz/Rp1PjxEHwBBDLRBMdhlX1LDI=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.1.0.tgz",
+          "integrity": "sha1-XkzspaN3njNlsVEeBfhmh3MC92A=",
           "dev": true,
-          "dependencies": {
-            "cliclopts": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
-              "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8=",
-              "dev": true
-            },
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "dev": true,
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-                  "dev": true
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-              "dev": true
-            }
+          "requires": {
+            "cliclopts": "1.1.1",
+            "debug": "2.6.9",
+            "minimist": "1.2.0",
+            "xtend": "4.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "topo": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+          "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
           }
         },
         "wreck": {
@@ -4882,20 +6818,16 @@
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
           "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
           "dev": true,
-          "dependencies": {
-            "boom": {
-              "version": "2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-              "dev": true
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-              "dev": true
-            }
+          "requires": {
+            "boom": "2.10.1",
+            "hoek": "2.16.3"
           }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
         }
       }
     },
@@ -4925,32 +6857,96 @@
       "resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
       "integrity": "sha1-cq+DljARnluYw7AruMJ+MjcVgQU="
     },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dev": true,
+      "requires": {
+        "array-each": "1.0.1",
+        "array-slice": "1.0.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ="
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "opn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU="
+      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
@@ -4970,13 +6966,26 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "orchestrator": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.0"
+      }
     },
     "ordered-read-streams": {
       "version": "0.1.0",
@@ -4992,7 +7001,11 @@
     "os-name": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
-      "integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8="
+      "integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8=",
+      "requires": {
+        "osx-release": "1.1.0",
+        "win-release": "1.1.1"
+      }
     },
     "os-shim": {
       "version": "0.1.3",
@@ -5007,17 +7020,32 @@
     "osenv": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "osx-release": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
-      "integrity": "sha1-8heRGigTaUmvG/kwiyQeJzfTzWw="
+      "integrity": "sha1-8heRGigTaUmvG/kwiyQeJzfTzWw=",
+      "requires": {
+        "minimist": "1.2.0"
+      }
     },
     "p-any": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-any/-/p-any-1.0.0.tgz",
-      "integrity": "sha1-XBcQtjlw1axOLFrpibiW8mzTmvo="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-any/-/p-any-1.1.0.tgz",
+      "integrity": "sha512-Ef0tVa4CZ5pTAmKn+Cg3w8ABBXh+hHO1aV8281dKOoUHfX+3tjG2EaFcC+aZyagg9b4EYGsHEjz21DnEE8Og2g==",
+      "requires": {
+        "p-some": "2.0.0"
+      }
+    },
+    "p-cancelable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -5032,12 +7060,26 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM="
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "requires": {
+        "p-limit": "1.1.0"
+      }
     },
     "p-some": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-some/-/p-some-1.1.0.tgz",
-      "integrity": "sha1-fmOI8/Bs+7Tsv7k/DTJLeF77nsY="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-some/-/p-some-2.0.0.tgz",
+      "integrity": "sha512-CsRc5gwQNJgSh+pNaGUtgBWBSh9btl8jYLbIdeqLgOLAATZmDDX7xTS5V0mqJk5Dw0gz8FF6s8sAF4D0MvxLhw==",
+      "requires": {
+        "aggregate-error": "1.0.0"
+      }
+    },
+    "p-timeout": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+      "requires": {
+        "p-finally": "1.0.0"
+      }
     },
     "p-try": {
       "version": "1.0.0",
@@ -5048,11 +7090,34 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
       "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+      "requires": {
+        "got": "5.7.1",
+        "registry-auth-token": "3.3.1",
+        "registry-url": "3.1.0",
+        "semver": "5.4.1"
+      },
       "dependencies": {
         "got": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-          "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU="
+          "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+          "requires": {
+            "create-error-class": "3.0.2",
+            "duplexer2": "0.1.4",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.0",
+            "node-status-codes": "1.0.0",
+            "object-assign": "4.1.1",
+            "parse-json": "2.2.0",
+            "pinkie-promise": "2.0.1",
+            "read-all-stream": "3.1.0",
+            "readable-stream": "2.3.3",
+            "timed-out": "3.1.3",
+            "unzip-response": "1.0.2",
+            "url-parse-lax": "1.0.0"
+          }
         },
         "timed-out": {
           "version": "3.1.3",
@@ -5075,23 +7140,40 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
       "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-absolute": "0.2.6",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "parse-help": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/parse-help/-/parse-help-0.1.1.tgz",
-      "integrity": "sha1-L035Qud6VYG7qZZ8DD9I5MZtfdo="
+      "integrity": "sha1-L035Qud6VYG7qZZ8DD9I5MZtfdo=",
+      "requires": {
+        "execall": "1.0.0"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -5103,28 +7185,51 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/passwd-user/-/passwd-user-2.1.0.tgz",
       "integrity": "sha1-+tnbauJS+LCI4MXezSCn2gxdnx4=",
+      "requires": {
+        "execa": "0.4.0",
+        "pify": "2.3.0"
+      },
       "dependencies": {
         "execa": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M="
+          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
+          "requires": {
+            "cross-spawn-async": "2.2.5",
+            "is-stream": "1.1.0",
+            "npm-run-path": "1.0.0",
+            "object-assign": "4.1.1",
+            "path-key": "1.0.0",
+            "strip-eof": "1.0.0"
+          }
         },
         "npm-run-path": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8="
+          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
+          "requires": {
+            "path-key": "1.0.0"
+          }
         },
         "path-key": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
           "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -5134,8 +7239,7 @@
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "2.0.1",
@@ -5152,7 +7256,10 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-root-regex": "0.1.2"
+      }
     },
     "path-root-regex": {
       "version": "0.1.2",
@@ -5163,17 +7270,29 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE="
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
+      }
     },
     "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -5183,24 +7302,46 @@
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pkg-conf": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz",
       "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
       "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "load-json-file": "2.0.0"
+      },
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
         },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "strip-bom": {
@@ -5215,19 +7356,39 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
     },
     "pkg-up": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
-      "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
     },
     "plur": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "1.4.0"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -5286,6 +7447,11 @@
       "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
       "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
       "dev": true,
+      "requires": {
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.1.7"
+      },
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
@@ -5306,55 +7472,131 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "randomatic": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-      "dev": true
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
     },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      }
     },
     "read-all-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po="
+      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "requires": {
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.3"
+      }
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
     },
     "read-pkg-up": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      },
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c="
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "2.0.0"
+          }
         },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg="
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
         },
         "path-type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM="
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg="
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -5364,26 +7606,36 @@
       }
     },
     "readable-stream": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-        }
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "mute-stream": {
           "version": "0.0.5",
@@ -5396,40 +7648,60 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "1.5.0"
+      }
     },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      },
       "dependencies": {
         "indent-string": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA="
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "requires": {
+            "repeating": "2.0.1"
+          }
         }
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
     },
     "registry-auth-token": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY="
+      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "requires": {
+        "rc": "1.2.2",
+        "safe-buffer": "5.1.1"
+      }
     },
     "registry-url": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI="
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "requires": {
+        "rc": "1.2.2"
+      }
     },
     "remove-trailing-separator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
-      "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
@@ -5447,41 +7719,72 @@
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "replace-ext": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
     },
-    "req-all": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/req-all/-/req-all-1.0.0.tgz",
-      "integrity": "sha1-0ShWlFHDQLQyQJxlbPFmJgzSYo0=",
-      "dev": true
-    },
     "req-cwd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
       "integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "req-from": "1.0.1"
+      }
     },
     "req-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/req-from/-/req-from-1.0.1.tgz",
       "integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve-from": "2.0.0"
+      }
     },
     "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      }
     },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      },
       "dependencies": {
         "resolve-from": {
           "version": "1.0.1",
@@ -5492,22 +7795,32 @@
       }
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
       "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve-from": "2.0.0"
+      }
     },
     "resolve-dir": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-tilde": "1.2.2",
+        "global-modules": "0.2.3"
+      }
     },
     "resolve-from": {
       "version": "2.0.0",
@@ -5518,14 +7831,21 @@
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368="
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.2.8",
@@ -5536,12 +7856,19 @@
     "root-check": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/root-check/-/root-check-1.0.0.tgz",
-      "integrity": "sha1-xSp5S/Dbn61WdTbkGJjwyeCoZpc="
+      "integrity": "sha1-xSp5S/Dbn61WdTbkGJjwyeCoZpc=",
+      "requires": {
+        "downgrade-root": "1.2.2",
+        "sudo-block": "1.2.0"
+      }
     },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA="
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "requires": {
+        "is-promise": "2.1.0"
+      }
     },
     "rx": {
       "version": "4.1.0",
@@ -5556,12 +7883,15 @@
     "rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74="
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
     },
     "safe-buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-      "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
       "version": "1.1.2",
@@ -5575,14 +7905,17 @@
       "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY="
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "requires": {
+        "semver": "5.4.1"
+      }
     },
     "semver-regex": {
       "version": "1.0.0",
@@ -5592,7 +7925,10 @@
     "semver-truncate": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
-      "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g="
+      "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
+      "requires": {
+        "semver": "5.4.1"
+      }
     },
     "sequencify": {
       "version": "0.0.7",
@@ -5608,7 +7944,10 @@
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo="
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -5620,13 +7959,10 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
-        }
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.4",
+        "rechoir": "0.6.2"
       }
     },
     "sigmund": {
@@ -5644,7 +7980,13 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -5664,27 +8006,40 @@
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.0"
+      }
     },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
     },
     "sort-on": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-on/-/sort-on-2.0.0.tgz",
-      "integrity": "sha1-DfQqZ5165K7Zwwui9VgH2XmRD8w="
+      "integrity": "sha1-DfQqZ5165K7Zwwui9VgH2XmRD8w=",
+      "requires": {
+        "arrify": "1.0.1",
+        "dot-prop": "4.2.0"
+      }
     },
     "source-map": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
       "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
     },
     "sparkles": {
       "version": "1.0.0",
@@ -5695,12 +8050,19 @@
     "spawn-sync": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY="
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "os-shim": "0.1.3"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -5719,15 +8081,18 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "stream-consume": {
@@ -5736,27 +8101,45 @@
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-        }
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-      "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w="
+      "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+      "requires": {
+        "strip-ansi": "3.0.1"
+      }
     },
     "string-width": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-      "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -5766,17 +8149,27 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-bom-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
-      "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco="
+      "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+      "requires": {
+        "first-chunk-stream": "2.0.0",
+        "strip-bom": "2.0.0"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -5786,7 +8179,10 @@
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI="
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -5796,7 +8192,12 @@
     "sudo-block": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/sudo-block/-/sudo-block-1.2.0.tgz",
-      "integrity": "sha1-zFOb+BkWJNT1B9g+60W0zqJ/NGM="
+      "integrity": "sha1-zFOb+BkWJNT1B9g+60W0zqJ/NGM=",
+      "requires": {
+        "chalk": "1.1.3",
+        "is-docker": "1.1.0",
+        "is-root": "1.0.0"
+      }
     },
     "supports-color": {
       "version": "2.0.0",
@@ -5807,12 +8208,40 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
+      }
     },
     "tabtab": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/tabtab/-/tabtab-1.3.2.tgz",
       "integrity": "sha1-u5wspjJPZZ/edjTCyvPAluEYfKc=",
+      "requires": {
+        "debug": "2.6.9",
+        "inquirer": "1.2.3",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "npmlog": "2.0.4",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "ansi-escapes": {
           "version": "1.4.0",
@@ -5822,27 +8251,58 @@
         "cli-cursor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc="
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
         },
         "external-editor": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs="
+          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+          "requires": {
+            "extend": "3.0.1",
+            "spawn-sync": "1.0.15",
+            "tmp": "0.0.29"
+          }
         },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4="
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
         },
         "inquirer": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
-          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg="
+          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.2.0",
+            "external-editor": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "4.17.4",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "2.0.1",
+            "run-async": "2.3.0",
+            "rx": "4.1.0",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "mute-stream": {
           "version": "0.0.6",
@@ -5857,50 +8317,72 @@
         "restore-cursor": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE="
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "tmp": {
           "version": "0.0.29",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA="
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
         }
       }
     },
     "taketalk": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
-      "integrity": "sha1-tNTw3u0gauffd1sSnqLKbeUvJt0="
+      "integrity": "sha1-tNTw3u0gauffd1sSnqLKbeUvJt0=",
+      "requires": {
+        "get-stdin": "4.0.1",
+        "minimist": "1.2.0"
+      }
     },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
+      }
     },
     "term-size": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
-      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "requires": {
+        "execa": "0.7.0"
+      },
       "dependencies": {
         "execa": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M="
-        },
-        "npm-run-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8="
-        },
-        "path-key": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-          "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
         }
       }
     },
@@ -5923,13 +8405,20 @@
     "through2": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
     },
     "tildify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "time-stamp": {
       "version": "1.1.0",
@@ -5948,14 +8437,20 @@
       "integrity": "sha1-fTUHIgYYMLpmF2MeDP0+oIOY2Vo="
     },
     "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc="
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -5971,7 +8466,10 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -5982,13 +8480,20 @@
     "twig": {
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/twig/-/twig-0.8.9.tgz",
-      "integrity": "sha1-sVlPACtoTl8CnePlToe+xPCEtsI="
+      "integrity": "sha1-sVlPACtoTl8CnePlToe+xPCEtsI=",
+      "requires": {
+        "minimatch": "3.0.4",
+        "walk": "2.3.9"
+      }
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-detect": {
       "version": "1.0.0",
@@ -6002,16 +8507,21 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
-      "version": "2.8.28",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.28.tgz",
-      "integrity": "sha512-WqKNbmNJKzIdIEQu/U2ytgGBbhCy2PVks94GoetczOAJ/zCgVu2CuO7gguI5KPFGPtUtI1dmPQl6h0D4cPzypA==",
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true,
           "optional": true
         }
@@ -6039,7 +8549,15 @@
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo="
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "requires": {
+        "crypto-random-string": "1.0.0"
+      }
+    },
+    "untildify": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
+      "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
     },
     "unzip-response": {
       "version": "2.0.1",
@@ -6047,25 +8565,78 @@
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
     },
     "update-notifier": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
-      "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "requires": {
+        "boxen": "1.2.2",
+        "chalk": "2.3.0",
+        "configstore": "3.1.1",
+        "import-lazy": "2.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM="
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8="
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -6081,15 +8652,18 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "v8flags": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      },
       "dependencies": {
         "user-home": {
           "version": "1.1.1",
@@ -6102,28 +8676,67 @@
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
     },
     "vinyl": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ="
+      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+      "requires": {
+        "clone": "1.0.3",
+        "clone-stats": "0.0.1",
+        "replace-ext": "0.0.1"
+      }
     },
     "vinyl-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
-      "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo="
+      "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "2.0.0",
+        "vinyl": "1.2.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
+      }
     },
     "vinyl-fs": {
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
+      "requires": {
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
+      },
       "dependencies": {
         "clone": {
           "version": "0.2.0",
@@ -6141,7 +8754,10 @@
           "version": "3.0.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "natives": "1.1.0"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -6153,7 +8769,13 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -6165,19 +8787,31 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
           "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "first-chunk-stream": "1.0.0",
+            "is-utf8": "0.2.1"
+          }
         },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
         },
         "vinyl": {
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
+          }
         }
       }
     },
@@ -6186,11 +8820,14 @@
       "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -6198,34 +8835,54 @@
     "walk": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
-      "integrity": "sha1-MbTbZnjyrgHDnqn7hyWpAx5Vins="
+      "integrity": "sha1-MbTbZnjyrgHDnqn7hyWpAx5Vins=",
+      "requires": {
+        "foreachasync": "3.0.0"
+      }
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "widest-line": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "requires": {
+        "string-width": "1.0.2"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
     "win-release": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk="
+      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+      "requires": {
+        "semver": "5.4.1"
+      }
     },
     "window-size": {
       "version": "0.1.0",
@@ -6244,16 +8901,28 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -6266,24 +8935,55 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "write-file-atomic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
-      "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
+      }
     },
     "write-json-file": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.2.0.tgz",
-      "integrity": "sha1-UYYlBruzthnu+reFnx/WxtBTCHY=",
-      "dev": true
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+      "dev": true,
+      "requires": {
+        "detect-indent": "5.0.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.1.0",
+        "pify": "3.0.0",
+        "sort-keys": "2.0.0",
+        "write-file-atomic": "2.3.0"
+      },
+      "dependencies": {
+        "sort-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "dev": true,
+          "requires": {
+            "is-plain-obj": "1.1.0"
+          }
+        }
+      }
     },
     "write-pkg": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-2.1.0.tgz",
       "integrity": "sha1-NTqkTDnEjCFED1wIzmq9RhQcnAg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sort-keys": "1.1.2",
+        "write-json-file": "2.3.0"
+      }
     },
     "xdg-basedir": {
       "version": "3.0.0",
@@ -6295,29 +8995,38 @@
       "resolved": "https://registry.npmjs.org/xo/-/xo-0.18.2.tgz",
       "integrity": "sha1-kqQusCpPsUnf6lUYAhkU9arIT/A=",
       "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "debug": "2.6.9",
+        "deep-assign": "1.0.0",
+        "eslint": "3.19.0",
+        "eslint-config-xo": "0.18.2",
+        "eslint-formatter-pretty": "1.3.0",
+        "eslint-plugin-ava": "4.2.2",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-no-use-extend-native": "0.3.12",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-unicorn": "2.1.2",
+        "get-stdin": "5.0.1",
+        "globby": "6.1.0",
+        "has-flag": "2.0.0",
+        "ignore": "3.3.7",
+        "lodash.isequal": "4.5.0",
+        "meow": "3.7.0",
+        "multimatch": "2.1.0",
+        "path-exists": "3.0.0",
+        "pkg-conf": "2.0.0",
+        "resolve-cwd": "1.0.0",
+        "resolve-from": "2.0.0",
+        "slash": "1.0.0",
+        "update-notifier": "2.3.0",
+        "xo-init": "0.5.0"
+      },
       "dependencies": {
         "get-stdin": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
           "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
-        },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "path-exists": {
@@ -6333,24 +9042,50 @@
       "resolved": "https://registry.npmjs.org/xo-init/-/xo-init-0.5.0.tgz",
       "integrity": "sha1-jijex5Z2zF4EL95f2PcQ4mRrDjY=",
       "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "execa": "0.5.1",
+        "minimist": "1.2.0",
+        "path-exists": "3.0.0",
+        "read-pkg-up": "2.0.0",
+        "the-argv": "1.0.0",
+        "write-pkg": "2.1.0"
+      },
       "dependencies": {
         "cross-spawn": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
         },
         "execa": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
           "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "get-stream": "2.3.1",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "path-exists": {
           "version": "3.0.0",
@@ -6376,6 +9111,12 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
@@ -6390,55 +9131,127 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/yeoman-character/-/yeoman-character-1.1.0.tgz",
       "integrity": "sha1-kNS1vq+SdZCGF3AVsv36LgaE18c=",
+      "requires": {
+        "supports-color": "3.2.3"
+      },
       "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY="
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
     "yeoman-doctor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/yeoman-doctor/-/yeoman-doctor-2.1.0.tgz",
-      "integrity": "sha1-lKt4SJamT1Op+sRS1ekTPidQojY="
+      "integrity": "sha1-lKt4SJamT1Op+sRS1ekTPidQojY=",
+      "requires": {
+        "bin-version-check": "2.1.0",
+        "chalk": "1.1.3",
+        "each-async": "1.1.1",
+        "log-symbols": "1.0.2",
+        "object-values": "1.0.0",
+        "semver": "5.4.1",
+        "twig": "0.8.9",
+        "user-home": "2.0.0"
+      }
     },
     "yeoman-environment": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.0.tgz",
-      "integrity": "sha1-2vovxRLBaMuDE0U+UxjmRzEmWRU=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.5.tgz",
+      "integrity": "sha512-6/W7/B54OPHJXob0n0+pmkwFsirC8cokuQkPSmT/D0lCcSxkKtg/BA6ZnjUBIwjuGqmw3DTrT4en++htaUju5g==",
+      "requires": {
+        "chalk": "2.3.0",
+        "debug": "3.1.0",
+        "diff": "3.4.0",
+        "escape-string-regexp": "1.0.5",
+        "globby": "6.1.0",
+        "grouped-queue": "0.3.3",
+        "inquirer": "3.3.0",
+        "is-scoped": "1.0.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "mem-fs": "1.1.3",
+        "text-table": "0.2.0",
+        "untildify": "3.0.2"
+      },
       "dependencies": {
-        "diff": {
+        "ansi-styles": {
           "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
         },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
         },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw="
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
-        "untildify": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
-          "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
+        "log-symbols": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+          "requires": {
+            "chalk": "2.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
     "yosay": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.0.tgz",
-      "integrity": "sha1-Dz0rsB9/JTYsEnIS9TwVcpBjM/4=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.1.tgz",
+      "integrity": "sha512-hN+Ft6X4Fq1uiguexEthlb6ba/RCx2DGF8fznsS166MDWbT7BzUxAJUOYnVMn+YdDE5VDMuRrkGFkUOdu5hvbA==",
+      "requires": {
+        "ansi-regex": "2.1.1",
+        "ansi-styles": "3.2.0",
+        "chalk": "1.1.3",
+        "cli-boxes": "1.0.0",
+        "pad-component": "0.0.1",
+        "string-width": "2.1.1",
+        "strip-ansi": "3.0.1",
+        "taketalk": "1.0.0",
+        "wrap-ansi": "2.1.0"
+      },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.0.0.tgz",
-          "integrity": "sha1-VATpOlRMT+x/BIJil3vr/jFV4ME="
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "insight": "^0.8.4",
     "lodash": "^4.17.4",
     "meow": "^3.0.0",
-    "npm-keyword": "^4.1.0",
+    "npm-keyword": "^5.0.0",
     "opn": "^4.0.2",
     "package-json": "^2.1.0",
     "parse-help": "^0.1.1",

--- a/test/route-install.js
+++ b/test/route-install.js
@@ -30,14 +30,14 @@ describe('install route', () => {
 
   describe('npm success with results', () => {
     beforeEach(function () {
-      this.rows = [
-        {key: ['yeoman-generator', 'generator-unicorn', 'some unicorn']},
-        {key: ['yeoman-generator', 'generator-unrelated', 'some description']},
-        {key: ['yeoman-generator', 'generator-unicorn-1', 'foo description']},
-        {key: ['yeoman-generator', 'generator-foo', 'description with unicorn word']},
-        {key: ['yeoman-generator', 'generator-blacklist-1', 'foo description']},
-        {key: ['yeoman-generator', 'generator-blacklist-2', 'foo description']},
-        {key: ['yeoman-generator', 'generator-blacklist-3', 'foo description']}
+      this.objects = [
+        {package: {name: 'generator-unicorn', description: 'some unicorn'}},
+        {package: {name: 'generator-unrelated', description: 'some description'}},
+        {package: {name: 'generator-unicorn-1', description: 'foo description'}},
+        {package: {name: 'generator-foo', description: 'description with unicorn word'}},
+        {package: {name: 'generator-blacklist-1', description: 'foo description'}},
+        {package: {name: 'generator-blacklist-2', description: 'foo description'}},
+        {package: {name: 'generator-blacklist-3', description: 'foo description'}}
       ];
 
       this.blacklist = [
@@ -52,9 +52,11 @@ describe('install route', () => {
       };
 
       nock(registryUrl)
-        .get('/-/_view/byKeyword')
+        .get('/-/v1/search')
           .query(true)
-          .reply(200, {rows: this.rows})
+          .reply(200, {
+            objects: this.objects
+          })
         .filteringPath(/\/[^?]+$/g, '/pkg')
           .get('/pkg')
           .times(4)
@@ -176,12 +178,12 @@ describe('install route', () => {
   describe('npm success without results', () => {
     beforeEach(() => {
       nock(registryUrl)
-        .get('/-/_view/byKeyword')
+        .get('/-/v1/search')
         .query(true)
         .reply(200, {
-          rows: [
-            {key: ['yeoman-generator', 'generator-unrelated', 'some description']},
-            {key: ['yeoman-generator', 'generator-unrelevant', 'some description']}
+          objects: [
+            {package: {name: 'generator-unrelated', description: 'some description'}},
+            {package: {name: 'generator-unrelevant', description: 'some description'}}
           ]
         });
     });


### PR DESCRIPTION
Closes #544

## Purpose of this pull request? 

- [ ] Documentation update
- [x] Bug fix 
- [ ] Enhancement
- [ ] Other, please explain:

## What changes did you make?

Updated npm-keyword to use the new npm API to search for Yeoman generators.

Since the new API restricts the number of results we need to pass the combination of `yeoman-generator` + `searchterm` to npm-keyword.

## Is there anything you'd like reviewers to focus on?

I wonder if it’s still necessary to `memoize` the result since the result of this request is now going to change with every different searchterm  and the result is limited to 250 generators:
https://github.com/yeoman/yo/blob/a4b7be3eeb44cdc62b9f018039482ba189a94875/lib/routes/install.js#L44