### PR TITLE
Added global-tunnel-ng to allow usage behind a proxy

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,6 +16,9 @@ const Router = require('./router');
 
 const gens = list(process.argv.slice(2));
 
+// Override http networking to go through a proxy ifone is configured
+require('global-tunnel-ng').initialize();
+
 /* eslint new-cap: 0, no-extra-parens: 0 */
 const tabtab = new Tabtab.Commands.default({
   name: 'yo',

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cross-spawn": "^5.0.1",
     "figures": "^2.0.0",
     "fullname": "^3.2.0",
+    "global-tunnel-ng": "^2.1.1",
     "got": "^8.0.3",
     "humanize-string": "^1.0.0",
     "inquirer": "^3.0.1",


### PR DESCRIPTION
## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [x] Enhancement
- [ ] Other, please explain:

## What changes did you make?

Included [global-tunnel-ng](https://github.com/np-maintain/global-tunnel) that overrides Node's [ Agent](https://nodejs.org/api/http.html#http_class_http_agent) with an Agent capable of tunneling through a proxy. Because `global-tunnel` is initialized with no parameters, the Agent will be overwritten only if a proxy is configured in the widely used environment variables `http_proxy` and `https_proxy`, so this should have no effect for users who are not explicitly using a proxy.

The most common use case is to set these variables at a `.bashrc` or `.zshrc` file, to have them on every shell session

```bash
export http_proxy="http://www.proxy.com"
```

Implementing this in `yo` was suggested in a [PR for `generator-node`](https://github.com/yeoman/generator-node/pull/277)

## Is there anything you'd like reviewers to focus on?

Everyone who had problems running a generator while using a proxy could try again and share the results. Only generators that use `http` or `https` either directly or in a dependency should be considered.

Clone this version of `yo` and link it globally

```bash
git clone https://github.com/MarcoScabbiolo/yo.git
cd yo
npm link -g
```

Then run your generators and share your results in this PR.

You can unlink the module after you're done by going back to the directory where you just cloned the repo and running

```bash
npm unlink -g
```

## Generators tested behind a proxy

- [ ] node 
