### PR TITLE
Bump global-tunnel-ng to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -816,6 +816,15 @@
         "write-file-atomic": "^2.3.0"
       }
     },
+    "config-chain": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "configstore": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
@@ -2327,11 +2336,12 @@
       }
     },
     "global-tunnel-ng": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.2.0.tgz",
-      "integrity": "sha1-ymUewPx4o1Bm9zOP/B4SgcZe6BM=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.4.0.tgz",
+      "integrity": "sha1-l6GEcVDn8i7TB3GjWqpJIjJ6eVc=",
       "requires": {
         "lodash": "^4.17.10",
+        "npm-conf": "^1.1.3",
         "tunnel": "^0.0.5"
       }
     },
@@ -3782,6 +3792,15 @@
         "prepend-http": "^2.0.0",
         "query-string": "^5.0.1",
         "sort-keys": "^2.0.0"
+      }
+    },
+    "npm-conf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+      "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+      "requires": {
+        "config-chain": "^1.1.11",
+        "pify": "^3.0.0"
       }
     },
     "npm-keyword": {
@@ -6482,6 +6501,11 @@
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
       "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
       "dev": true
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
     },
     "proto-props": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cross-spawn": "^6.0.5",
     "figures": "^2.0.0",
     "fullname": "^3.2.0",
-    "global-tunnel-ng": "^2.2.0",
+    "global-tunnel-ng": "^2.4.0",
     "got": "^8.3.2",
     "humanize-string": "^1.0.2",
     "inquirer": "^6.0.0",


### PR DESCRIPTION
Version 2.4.0 of [`global-tunnel-ng`](https://github.com/np-maintain/global-tunnel) includes:

- Improved [auto config](https://github.com/np-maintain/global-tunnel#auto-config) adding the npm proxy configuration as a source. Keys are`https-proxy`, `http-proxy` and `proxy`, in that order of relevance.
- Greenkeeper set
- Dependency review