### PR TITLE
fix: add override for deprecated

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4050,9 +4050,10 @@
       }
     },
     "node_modules/clone-stats": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==",
+      "name": "clone-stats-node22",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats-node22/-/clone-stats-node22-1.0.1.tgz",
+      "integrity": "sha512-Drr/D3UQBUFuwpFdCcnlJLOD0P7tosF8vF9jVjoRjl9gitDVDpNVoAAF9+h3pILY30t0MpMRzmxCs/vRQ6MvtQ==",
       "license": "MIT"
     },
     "node_modules/cmd-shim": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "files": [
-    "lib"
+    "lib",
+    "npm-shrinkwrap.json"
   ],
   "keywords": [
     "cli-app",
@@ -83,6 +84,9 @@
     "registry-url": "^5.1.0",
     "sinon": "^19.0.2",
     "xo": "0.38.0"
+  },
+  "overrides": {
+    "clone-stats": "npm:clone-stats-node22"
   },
   "resolutions": {
     "natives": "1.1.3"


### PR DESCRIPTION
<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/yeoman/blob/master/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [X] Enhancement
- [ ] Other, please explain:

## What changes did you make?

- Add `override` from deprecated `clone-stats` to its modern fork
- Add `npm-shrinkwrap.json` to the package to ensure the `override` is respected during `npm install -g`

## Is there anything you'd like reviewers to focus on?

Fixes #844
