### PR TITLE
Revert "ci: remove dependabot as we use renovate now"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+updates:
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+      open-pull-requests-limit: 10
+      ignore:
+          # ESM only version
+          - dependency-name: 'configstore'
+            versions: ['>=6']
+          # ESM only version
+          - dependency-name: 'got'
+            versions: ['>=9']
+          # ESM only version
+          - dependency-name: 'figures'
+            versions: ['>=4']
+          # ESM only version
+          - dependency-name: 'fullname'
+            versions: ['>=5']
+          # Avoid breaking changes to existing generators, kebab-case vs camelCase argument behavior changes needs to be properly tested
+          - dependency-name: 'meow'
+            versions: ['>=6']
+          # ESM only version
+          - dependency-name: 'npm-keyword'
+            versions: ['>=7']
+          # ESM only version
+          - dependency-name: 'open'
+            versions: ['>=9']
+          # ESM only version
+          - dependency-name: 'p-queue'
+            versions: ['>=7']
+          # ESM only version
+          - dependency-name: 'package-json'
+            versions: ['>=7']
+          # ESM only version
+          - dependency-name: 'read-pkg-up'
+            versions: ['>=8']
+          # ESM only version
+          - dependency-name: 'sort-on'
+            versions: ['>=5']
+          # ESM only version
+          - dependency-name: 'string-length'
+            versions: ['>=5']
+          # ESM only version
+          - dependency-name: 'update-notifier'
+            versions: ['>=6']
+          # ESM only version
+          - dependency-name: 'yeoman-character'
+            versions: ['>=2']
+          # ESM only version
+          - dependency-name: 'titleize'
+            versions: ['>=3']
+          # ESM only version
+          - dependency-name: 'yosay'
+            versions: ['>=3']
+          - dependency-name: '*'
+            update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      open-pull-requests-limit: 0


### PR DESCRIPTION
Renovate is not working as expected.

Reverts yeoman/yo#857